### PR TITLE
Fix UpnpSendAdvertisement() expiration limit

### DIFF
--- a/upnp/inc/upnp.h
+++ b/upnp/inc/upnp.h
@@ -1125,7 +1125,11 @@ EXPORT_SPEC int UpnpSearchAsync(
 EXPORT_SPEC int UpnpSendAdvertisement(
 	/*! The device handle for which to send out the announcements. */
 	UpnpDevice_Handle Hnd,
-	/*! The expiration age, in seconds, of the announcements. */
+	/*! The expiration age, in seconds, of the announcements. If the
+	 * expiration age is less than 1 then the expiration age is set to
+	 * \c DEFAULT_MAXAGE. If the expiration age is less than or equal to
+	 * \c AUTO_ADVERTISEMENT_TIME * 2 then the expiration age is set to
+	 * ( \c AUTO_ADVERTISEMENT_TIME + 1 ) * 2. */
 	int Exp);
 
 /*!
@@ -1149,7 +1153,11 @@ EXPORT_SPEC int UpnpSendAdvertisement(
 EXPORT_SPEC int UpnpSendAdvertisementLowPower(
         /*! The device handle for which to send out the announcements. */
         UpnpDevice_Handle Hnd,
-        /*! The expiration age, in seconds, of the announcements. */
+        /*! The expiration age, in seconds, of the announcements. If the
+         * expiration age is less than 1 then the expiration age is set to
+         * \c DEFAULT_MAXAGE. If the expiration age is less than or equal to 
+         * \c AUTO_ADVERTISEMENT_TIME * 2 then the expiration age is set to
+         * ( \c AUTO_ADVERTISEMENT_TIME + 1 ) * 2. */
         int Exp,
         /*! PowerState as defined by UPnP Low Power. */
         int PowerState,

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -1738,6 +1738,8 @@ int UpnpSendAdvertisementLowPower(UpnpDevice_Handle Hnd, int Exp,
     }
     if( Exp < 1 )
         Exp = DEFAULT_MAXAGE;
+    if( Exp <= AUTO_ADVERTISEMENT_TIME * 2 )
+        Exp = ( AUTO_ADVERTISEMENT_TIME + 1 ) * 2;
     SInfo->MaxAge = Exp;
     SInfo->PowerState = PowerState;
     if( SleepPeriod < 0 )


### PR DESCRIPTION
Do not allow the user to set an expiration limitation that is below
AUTO_ADVERTISEMENT_TIME * 2 otherwise advertisements will be sent
continuously or will be schedule in the past

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>