### PR TITLE
Update sample, test and unittest program names

### DIFF
--- a/ixml/Makefile.am
+++ b/ixml/Makefile.am
@@ -47,10 +47,10 @@ upnpinclude_HEADERS	= \
 			inc/ixml.h \
 			inc/ixmldebug.h
 
-check_PROGRAMS          = test_document
+check_PROGRAMS          = test_document-1.8
 TESTS                   = test/test_document.sh
 
-test_document_SOURCES 	= test/test_document.c
+test_document_1_8_SOURCES 	= test/test_document.c
 
 EXTRA_DIST		= test/test_document.sh test/testdata
 

--- a/ixml/test/test_document.sh
+++ b/ixml/test/test_document.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-./test_document `find $srcdir/test/testdata -name *.xml`
+./test_document-1.8 `find $srcdir/test/testdata -name *.xml`
 

--- a/upnp/Makefile.am
+++ b/upnp/Makefile.am
@@ -181,10 +181,10 @@ libupnp_1_8_la_SOURCES += \
 
 
 # check / distcheck tests
-check_PROGRAMS = test_init test_url
-TESTS = test_init test_url
-test_init_SOURCES = test/test_init.c
-test_url_SOURCES = test/test_url.c
+check_PROGRAMS = test_init-1.8 test_url-1.8
+TESTS = test_init-1.8 test_url-1.8
+test_init_1_8_SOURCES = test/test_init.c
+test_url_1_8_SOURCES = test/test_url.c
 
 
 EXTRA_DIST = \

--- a/upnp/sample/Makefile.am
+++ b/upnp/sample/Makefile.am
@@ -18,42 +18,42 @@ LDADD = \
 noinst_PROGRAMS =
 if ENABLE_SAMPLES
 if ENABLE_CLIENT
-noinst_PROGRAMS += tv_ctrlpt
-tv_ctrlpt_CPPFLAGS = \
+noinst_PROGRAMS += tv_ctrlpt-1.8
+tv_ctrlpt_1_8_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	-I$(srcdir)/common/ \
 	-I$(srcdir)/tvctrlpt
 if ENABLE_DEVICE
-noinst_PROGRAMS += tv_combo
-tv_combo_CPPFLAGS = $(AM_CPPFLAGS) \
+noinst_PROGRAMS += tv_combo-1.8
+tv_combo_1_8_CPPFLAGS = $(AM_CPPFLAGS) \
 	-I$(srcdir)/common/ \
 	-I$(srcdir)/tvcombo
 endif
 endif
 if ENABLE_DEVICE
-noinst_PROGRAMS += tv_device
-tv_device_CPPFLAGS = \
+noinst_PROGRAMS += tv_device-1.8
+tv_device_1_8_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
 	-I$(srcdir)/common/ \
 	-I$(srcdir)/tvdevice
 endif
 endif
 
-tv_device_SOURCES = \
+tv_device_1_8_SOURCES = \
 	common/sample_util.c \
 	common/sample_util.h \
 	common/tv_device.c \
 	common/tv_device.h \
 	linux/tv_device_main.c
 
-tv_ctrlpt_SOURCES = \
+tv_ctrlpt_1_8_SOURCES = \
 	common/sample_util.c \
 	common/sample_util.h \
 	common/tv_ctrlpt.c \
 	common/tv_ctrlpt.h \
 	linux/tv_ctrlpt_main.c
 
-tv_combo_SOURCES = \
+tv_combo_1_8_SOURCES = \
 	common/sample_util.c \
 	common/sample_util.h \
 	common/tv_ctrlpt.c \
@@ -65,8 +65,8 @@ tv_combo_SOURCES = \
 if WITH_DOCUMENTATION
 examplesdir = $(docdir)/examples
 examples_DATA = \
-	$(tv_ctrlpt_SOURCES) \
-	$(tv_device_SOURCES)
+	$(tv_ctrlpt_1_8_SOURCES) \
+	$(tv_device_1_8_SOURCES)
 endif
 
 EXTRA_DIST = \

--- a/upnp/unittest/Makefile.am
+++ b/upnp/unittest/Makefile.am
@@ -16,12 +16,12 @@ LDADD = \
 	$(top_builddir)/ixml/libixml-1.8.la
 
 #unittest
-noinst_PROGRAMS = unittest
+noinst_PROGRAMS = unittest-1.8
 
-unittest_CPPFLAGS = \
+unittest_1_8_CPPFLAGS = \
 	$(AM_CPPFLAGS)
 
-unittest_SOURCES = \
+unittest_1_8_SOURCES = \
 	main.c \
 	templates/FirstObject.c \
 	templates/FirstObject.h \


### PR DESCRIPTION
Update names of sample, test and unittest programs of 1.8.x branch to
avoid any collision with the programs of the "usual" 1.6.x branch

Rename:
 - tv_ctrlpt in tv_ctrlpt-1.8
 - tv_combo in tv_combo-1.8
 - tv_device in tv_device-1.8
 - unittest in unittest-1.8
 - test_init in test_init-1.8
 - test_url in test_url-1.8
 - test_document in test_document-1.8

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>