### PR TITLE
Use LFS functions in libixml

### DIFF
--- a/ixml/src/ixmlparser.c
+++ b/ixml/src/ixmlparser.c
@@ -35,6 +35,7 @@
  * \file
  */
 
+#include "autoconfig.h"
 
 #include "ixmlparser.h"
 


### PR DESCRIPTION
Even though the LFS defines (like `_FILE_OFFSET_BITS`) are setup, some parts of libixml were not using them because `autoconfig.h` had not been included.