### PR TITLE
Add option to use REUSEADDR on miniserver socket

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -496,6 +496,11 @@ if test "x$enable_postwrite" = xyes ; then
         AC_DEFINE(UPNP_ENABLE_POST_WRITE, 1, [see upnpconfig.h])
 fi
 
+RT_BOOL_ARG_ENABLE([reuseaddr], [no], [bind the miniserver socket with reuseaddr to allow clean restarts])
+if test "x$enable_reuseaddr" = xyes ; then
+        AC_DEFINE(UPNP_MINISERVER_REUSEADDR, 1, [see upnpconfig.h])
+fi
+
 RT_BOOL_ARG_ENABLE([samples], [yes], [compilation of upnp/sample/ code])
 
 

--- a/upnp/src/genlib/miniserver/miniserver.c
+++ b/upnp/src/genlib/miniserver/miniserver.c
@@ -523,7 +523,12 @@ static int get_miniserver_sockets(
 	uint16_t actual_port6 = 0u;
 #endif
 	int ret_code;
+#ifdef UPNP_MINISERVER_REUSEADDR
+	int reuseaddr_on = 1;
+#else
 	int reuseaddr_on = 0;
+#endif
+
 	int sockError = UPNP_E_SUCCESS;
 	int errCode = 0;
 


### PR DESCRIPTION
This adds a compile time option "--enable-reuseaddr" which enables the
previously unavailable SO_REUSEADDR codepath in miniserver.c

This allows us the normal advantages of REUSEADDR when implementing
servers that would like graceful restarts.

See v00d00/mediatomb#34