### PR TITLE
Fix syntax error in Makefile.am EXTRA_DIST introduced by b4a9ac0ddf212c7cd081fb62e0a101628ff0e6d2

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ EXTRA_DIST = \
 	build/inc/autoconfig.h \
 	build/inc/upnpconfig.h \
 	build/msvc/inttypes.h \
-	build/msvc/stdint.h \
+	build/msvc/stdint.h
 
 
 # This variable must have 'exec' in its name, in order to be installed 


### PR DESCRIPTION
a blank line can not follow a trailing backslash