### PR TITLE
Don't append flags like -O0/-Os which clobber the user's settings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -567,25 +567,6 @@ AC_PROG_EGREP
 echo "--------------------- Default compilation flags -------------------------------"
 echo host is $host
 echo host_os is $host_os
-case $host_os in
-freebsd*)
-	echo "Using FreeBSD specific compiler settings"
-	# Put FreeBSD specific compiler flags here
-	;;
-*)
-	echo "Using non-specific system compiler settings"
-	if test x"$enable_debug" = xyes; then
-		# AC_PROG_CC already sets CFLAGS to "-g -O2" by default,
-		# but only if CFLAGS was not previously set.
-		#:
-		# Use -O0 in debug so that variables do not get optimized out
-		AX_CFLAGS_GCC_OPTION([-O0, -g])
-	else
-		# add optimise for size
-		AX_CFLAGS_GCC_OPTION([-Os])
-	fi
-	;;
-esac
 
 AX_CFLAGS_WARN_ALL
 echo "-------------------------------------------------------------------------------"


### PR DESCRIPTION
This is patch we carry in Gentoo, its generally frowned upon to hard code these flags.