### PR TITLE
Simplify logging format

### DIFF
--- a/upnp/src/inc/upnpapi.h
+++ b/upnp/src/inc/upnpapi.h
@@ -137,21 +137,21 @@ Upnp_Handle_Type GetHandleInfo(
 
 
 #define HandleWriteLock()  \
-	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Trying a write lock"); \
+	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Trying a write lock\n"); \
 	ithread_rwlock_wrlock(&GlobalHndRWLock); \
-	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Write lock acquired");
+	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Write lock acquired\n");
 
 
 #define HandleReadLock()  \
-	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Trying a read lock"); \
+	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Trying a read lock\n"); \
 	ithread_rwlock_rdlock(&GlobalHndRWLock); \
-	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Read lock acquired");
+	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Read lock acquired\n");
 
 
 #define HandleUnlock() \
-	UpnpPrintf(UPNP_INFO, API,__FILE__, __LINE__, "Trying Unlock"); \
+	UpnpPrintf(UPNP_INFO, API,__FILE__, __LINE__, "Trying Unlock\n"); \
 	ithread_rwlock_unlock(&GlobalHndRWLock); \
-	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Unlocked rwlock");
+	UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__, "Unlocked rwlock\n");
 
 
 /*!


### PR DESCRIPTION
This change makes libupnp debug messages appear in a more traditional
log format, example below:

```
2017-06-07 22:22:42 UPNP: Thread:0x7F8085807700 [src/ssdp/ssdp_server.c:440]: Exiting AdvertiseAndReply.
2017-06-07 22:22:42 UPNP: Thread:0x7F8084805700 [src/ssdp/ssdp_ctrlpt.c:106]: Trying a read lock
```
This is makes it much easier to see what is going on, especially when
multiple things are happening, and includes the date/time for
correlation.

- Change the output file names to "libupnp_err.log" and "libupnp_info.log"
which more clearly describe their purpose.
- Fix the inverted check for DEBUG and write to stdout as expected.
- Fix some missing newlines in the lock logging.