### PR TITLE
Device eventing: add possibility to discard events based on age

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -512,11 +512,6 @@ if test "x$enable_unspecified_server" = xyes ; then
         AC_DEFINE(UPNP_ENABLE_UNSPECIFIED_SERVER, 1, [see upnpconfig.h])
 fi
 
-RT_BOOL_ARG_ENABLE([notification_reordering], [yes], [GENA notification reordering in gena_device.c])
-if test "x$enable_notification_reordering" = xyes ; then
-        AC_DEFINE(UPNP_ENABLE_NOTIFICATION_REORDERING, 1, [see upnpconfig.h])
-fi
-
 RT_BOOL_ARG_ENABLE([blocking_tcp_connections], [yes], [blocking TCP connections])
 if test "x$enable_blocking_tcp_connections" = xyes ; then
         AC_DEFINE(UPNP_ENABLE_BLOCKING_TCP_CONNECTIONS, 1, [see upnpconfig.h])

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -159,6 +159,22 @@ extern membuffer gDocumentRootDir;
  * error 413 (HTTP Error Code) will be returned to the remote end point. */
 size_t g_maxContentLength = DEFAULT_SOAP_CONTENT_LENGTH;
 
+/*! Global variable to determines the maximum number of
+ *  events which can be queued for a given subscription before events begin
+ *  to be discarded. This limits the amount of memory used for a
+ *  non-responding subscribed entity. */
+int g_UpnpSdkEQMaxLen = MAX_SUBSCRIPTION_QUEUED_EVENTS;
+
+/*! Global variable to determine the maximum number of 
+ *  seconds which an event can spend on a subscription queue (waiting for the 
+ *  event at the head of the queue to be communicated). This parameter will 
+ *  have no effect in most situations with the default (low) value of 
+ *  MAX_SUBSCRIPTION_QUEUED_EVENTS. However, if MAX_SUBSCRIPTION_QUEUED_EVENTS 
+ *  is set to a high value, the AGE parameter will allow pruning the queue in 
+ *  good conformance with the UPnP Device Architecture standard, at the 
+ *  price of higher potential memory use. */
+int g_UpnpSdkEQMaxAge = MAX_SUBSCRIPTION_EVENT_AGE;
+
 /*! Global variable to denote the state of Upnp SDK == 0 if uninitialized,
  * == 1 if initialized. */
 int UpnpSdkInit = 0;
@@ -4341,6 +4357,13 @@ int UpnpSetMaxContentLength(size_t contentLength)
 	} while(0);
 
 	return errCode;
+}
+
+int UpnpSetEventQueueLimits(int maxLen, int maxAge)
+{
+	g_UpnpSdkEQMaxLen = maxLen;
+	g_UpnpSdkEQMaxAge = maxAge;
+	return UPNP_E_SUCCESS;
 }
 
 /* @} UPnPAPI */

--- a/upnp/src/gena/gena_device.c
+++ b/upnp/src/gena/gena_device.c
@@ -574,7 +574,7 @@ static int genaInitNotifyCommon(
 		memset(thread_struct->sid, 0, sizeof(thread_struct->sid));
 		strncpy(thread_struct->sid, sid,
 			sizeof(thread_struct->sid) - 1);
-		thread_struct->eventKey = sub->eventKey++;
+		thread_struct->ctime = time(0);
 		thread_struct->reference_count = reference_count;
 		thread_struct->device_handle = device_handle;
 
@@ -705,6 +705,40 @@ ExitFunction:
 	return ret;
 }
 
+// This gets called before queuing a new event.
+// - The list size can never go over MAX_SUBSCRIPTION_QUEUED_EVENTS so we
+//   discard the oldest non-active event if it is already at the max
+// - We also discard any non-active event older than MAX_SUBSCRIPTION_EVENT_AGE.
+// non-active: any but the head of queue, which is already copied to
+// the thread pool
+static void maybeDiscardEvents(LinkedList *listp)
+{
+	time_t now = time(0L);
+
+	while (ListSize(listp) > 1) {
+		ListNode *node = ListHead(listp);
+		/* The first candidate is the second event: first non-active */
+		if (node == 0 || (node = node->next) == 0) {
+			/* Major inconsistency, really, should abort here. */
+			fprintf(stderr, "gena_device: maybeDiscardEvents: "
+					"list is inconsistent\n");
+			break;
+		}
+
+		notify_thread_struct *ntsp =
+			(notify_thread_struct *)(((ThreadPoolJob *)node->item)->arg);
+		if (ListSize(listp) > g_UpnpSdkEQMaxLen ||
+			now - ntsp->ctime > g_UpnpSdkEQMaxAge) {
+			free_notify_struct(ntsp);
+			free(node->item);
+			ListDelNode(listp, node, 0);
+		} else {
+			// If the list is smaller than the max and the oldest
+			// task is young enough, stop pruning
+			break;
+		}
+	}
+}
 
 /* We take ownership of propertySet and will free it */
 static int genaNotifyAllCommon(
@@ -789,29 +823,10 @@ static int genaNotifyAllCommon(
 					sizeof(thread_struct->sid));
 				strncpy(thread_struct->sid, finger->sid,
 					sizeof(thread_struct->sid) - 1);
-				thread_struct->eventKey = finger->eventKey++;
+				thread_struct->ctime = time(0);
 				thread_struct->device_handle = device_handle;
-				/* if overflow, wrap to 1 */
-				if (finger->eventKey < 0) {
-					finger->eventKey = 1;
-				}
 
-				if (ListSize(&finger->outgoing) >=
-					MAX_SUBSCRIPTION_QUEUED_EVENTS) {
-					/* We discard the second event: first non-active */
-					ListNode *node = ListHead(&finger->outgoing);
-					if (node)
-						node = node->next;
-					if (node) {
-						/* We delete the node ourselves because we also need
-						   to do the right thing about the thread struct */
-						job = (ThreadPoolJob *)node->item;
-						free_notify_struct((notify_thread_struct *)job->arg);
-						free(node->item);
-						ListDelNode(&finger->outgoing, node, 0);
-					}
-				}
-
+				maybeDiscardEvents(&finger->outgoing);
 				job = (ThreadPoolJob *)malloc(sizeof(ThreadPoolJob));
 				if (job == NULL) {
 					line = __LINE__;
@@ -1194,7 +1209,6 @@ void gena_process_subscription_request(
 		HandleUnlock();
 		goto exit_function;
 	}
-	sub->eventKey = 0;
 	sub->ToSendEventKey = 0;
 	sub->active = 0;
 	sub->next = NULL;

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -1764,6 +1764,10 @@ int http_MakeMessage(membuffer *buf, int http_major_version,
 			if (http_MakeMessage(buf, http_major_version, http_minor_version,
 					     "shc", "CONTENT-LENGTH: ", bignum) != 0)
 				goto error_handler;
+			// Add accept ranges
+			if (http_MakeMessage(buf, http_major_version, http_minor_version,
+								 "sc", "Accept-Ranges: bytes") != 0)
+				goto error_handler;
 		} else if (c == 'S' || c == 'U') {
 			/* SERVER or USER-AGENT header */
 			temp_str = (c == 'S') ? "SERVER: " : "USER-AGENT: ";

--- a/upnp/src/genlib/service_table/service_table.c
+++ b/upnp/src/genlib/service_table/service_table.c
@@ -66,7 +66,6 @@ copy_subscription( subscription * in,
 
     memcpy( out->sid, in->sid, SID_SIZE );
     out->sid[SID_SIZE] = 0;
-    out->eventKey = in->eventKey;
     out->ToSendEventKey = in->ToSendEventKey;
     out->expireTime = in->expireTime;
     out->active = in->active;

--- a/upnp/src/inc/config.h
+++ b/upnp/src/inc/config.h
@@ -151,7 +151,24 @@
  *
  * @{
  */
-#define MAX_SUBSCRIPTION_QUEUED_EVENTS 5
+#define MAX_SUBSCRIPTION_QUEUED_EVENTS 10
+/* @} */
+
+
+/*! \name MAX_SUBSCRIPTION_EVENT_AGE
+ *
+ *  The {\tt MAX_SUBSCRIPTION__EVENT_AGE} determines the maximum number of 
+ *  seconds which an event can spend on a subscription queue (waiting for the 
+ *  event at the head of the queue to be communicated). This parameter will 
+ *  have no effect in most situations with the default (low) value of 
+ *  MAX_SUBSCRIPTION_QUEUED_EVENTS. However, if MAX_SUBSCRIPTION_QUEUED_EVENTS 
+ *  is set to a high value, the AGE parameter will allow pruning the queue in 
+ *  good conformance with the UPnP Device Architecture standard, at the 
+ *  price of higher potential memory use.
+ *
+ * @{
+ */
+#define MAX_SUBSCRIPTION_EVENT_AGE 30
 /* @} */
 
 

--- a/upnp/src/inc/gena.h
+++ b/upnp/src/inc/gena.h
@@ -147,7 +147,7 @@ typedef struct NOTIFY_THREAD_STRUCT {
 	char *servId;
 	char *UDN;
 	Upnp_SID sid;
-	int eventKey;
+	time_t ctime;
 	int *reference_count;
 	UpnpDevice_Handle device_handle;
 } notify_thread_struct;

--- a/upnp/src/inc/service_table.h
+++ b/upnp/src/inc/service_table.h
@@ -56,7 +56,6 @@ extern "C" {
 
 typedef struct SUBSCRIPTION {
 	Upnp_SID sid;
-	int eventKey;
 	int ToSendEventKey;
 	time_t expireTime;
 	int active;

--- a/upnp/src/inc/upnpapi.h
+++ b/upnp/src/inc/upnpapi.h
@@ -59,6 +59,8 @@
 #define MAX_SOAP_CONTENT_LENGTH (size_t)32000
 
 extern size_t g_maxContentLength;
+extern int g_UpnpSdkEQMaxLen;
+extern int g_UpnpSdkEQMaxAge;
 
 /* 30-second timeout */
 #define UPNP_TIMEOUT	30


### PR DESCRIPTION
Add possibility to discard events destined to non-responding control point based on event age, in addition to maximum queue lenth.

- Delete eventKey field from event data structure: it was set but never used.
- Add ctime age field.
- Add max age configuration parameter.
- Define function for setting max queue size and max event age, in the case where compiled-in defaults are not appropriate.