### PR TITLE
extra headers

### DIFF
--- a/upnp/inc/upnp.h
+++ b/upnp/inc/upnp.h
@@ -799,6 +799,16 @@ struct Upnp_Subscription_Request
 
 };
 
+struct Extra_Headers
+{
+	/** The length of the file. A length less than 0 indicates the size
+	*  is unknown, and data will be sent until 0 bytes are returned from
+	*  a read call. */
+	char *name;
+	char *value;
+	DOMString resp;
+};
+
 struct File_Info
 {
 	/** The length of the file. A length less than 0 indicates the size 
@@ -822,6 +832,11 @@ struct File_Info
 	*  by the caller using {\bf ixmlCloneDOMString}.  When finished 
 	*  with it, the SDK frees the {\bf DOMString}. */
 	DOMString content_type;
+
+	/** Headers to be modified / added. A modified response must be allocated
+	* by the caller using {\bf ixmlCloneDOMString}.  When finished with it,
+	* the SDK frees all of them. */
+	struct Extra_Headers *extra_headers;
 };
 #endif /* UPNP_VERSION < 10800 */
 

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -1658,6 +1658,20 @@ int http_MakeMessage(membuffer *buf, int http_major_version,
 	memset(tempbuf, 0, sizeof(tempbuf));
 	va_start(argp, fmt);
 	while ((c = *fmt++)) {
+		if (c == 'E') {
+			struct Extra_Headers *extras;
+			/* array of extra headers */
+			extras = (struct Extra_Headers *) va_arg(argp, struct Extra_Headers *);
+			while (extras->name) {
+				if (extras->resp) {
+					if (membuffer_append(buf, extras->resp, strlen(extras->resp)))
+						goto error_handler;
+					if (membuffer_append(buf, "\r\n", (size_t)2))
+						goto error_handler;
+				}
+				extras++;
+			}
+		}
 		if (c == 's') {
 			/* C string */
 			s = (char *)va_arg(argp, char *);


### PR DESCRIPTION
Allow extra headers to be sent to client in the File_Info struct by adding extra_headers, an array of struct Extra_Headers.

It contains "name" and "value" and the callee can populate a DOMString "resp" to add a header as well in the reponse