### PR TITLE
Add userdata/cookie to virtualDir callbacks

### DIFF
--- a/upnp/inc/upnp.h
+++ b/upnp/inc/upnp.h
@@ -1099,7 +1099,7 @@ EXPORT_SPEC int UpnpSearchAsync(
 	 * specification. */
 	const char *TTarget_constarget_const,
 	/*! The user data to pass when the callback function is invoked. */
-	const void *Cookie_const); 
+	const void *Cookie_const);
 
 /*!
  * \brief Sends out the discovery announcements for all devices and services
@@ -2575,7 +2575,9 @@ typedef int (*VDCallback_GetInfo)(
 		/*! [in] The name of the file to query. */
 		const char *filename,
 		/*! [out] Pointer to a structure to store the information on the file. */
-		UpnpFileInfo *info);
+		UpnpFileInfo *info,
+		/*! [in] The cookie associated with this VirtualDir */
+		const void *cookie);
 
 /*!
  * \brief Sets the get_info callback function to be used to access a virtual
@@ -2595,7 +2597,9 @@ typedef UpnpWebFileHandle (*VDCallback_Open)(
 		const char *filename,
 		/*! [in] The mode in which to open the file.
 		 * Valid values are \c UPNP_READ or \c UPNP_WRITE. */
-		enum UpnpOpenFileMode Mode);
+		enum UpnpOpenFileMode Mode,
+		/*! [in] The cookie associated with this VirtualDir */
+		const void *cookie);
 
 /*!
  * \brief Sets the open callback function to be used to access a virtual
@@ -2616,7 +2620,9 @@ typedef int (*VDCallback_Read)(
 	/*! [out] The buffer in which to place the data. */
 	char *buf,
 	/*! [in] The size of the buffer (i.e. the number of bytes to read). */
-	size_t buflen);
+	size_t buflen,
+	/*! [in] The cookie associated with this VirtualDir */
+	const void *cookie);
 
 /*! 
  * \brief Sets the read callback function to be used to access a virtual
@@ -2637,7 +2643,9 @@ typedef	int (*VDCallback_Write)(
 	/*! [in] The buffer with the bytes to write. */
 	char *buf,
 	/*! [in] The number of bytes to write. */
-	size_t buflen);
+	size_t buflen,
+	/*! [in] The cookie associated with this VirtualDir */
+	const void *cookie);
 
 /*!
  * \brief Sets the write callback function to be used to access a virtual
@@ -2663,7 +2671,9 @@ typedef int (*VDCallback_Seek) (
 	 * to move relative to the current position, \c SEEK_END to
 	 * move relative to the end of the file, or \c SEEK_SET to
 	 * specify an absolute offset. */
-	int origin);
+	int origin,
+	/*! [in] The cookie associated with this VirtualDir */
+	const void *cookie);
 
 /*!
  * \brief Sets the seek callback function to be used to access a virtual
@@ -2680,7 +2690,9 @@ EXPORT_SPEC int UpnpVirtualDir_set_SeekCallback(VDCallback_Seek callback);
  */
 typedef int (*VDCallback_Close)(
 		/*! [in] The handle of the file to close. */
-		UpnpWebFileHandle fileHnd);
+		UpnpWebFileHandle fileHnd,
+		/*! [in] The cookie associated with this VirtualDir */
+		const void *cookie);
 
 /*!
  * \brief Sets the close callback function to be used to access a virtual
@@ -2728,7 +2740,11 @@ EXPORT_SPEC int UpnpIsWebserverEnabled(void);
  */
 EXPORT_SPEC int UpnpAddVirtualDir(
 	/*! [in] The name of the new directory mapping to add. */
-	const char *dirName);
+	const char *dirName,
+	/*! [in] The cookie to associated with this virtual directory */
+	const void *cookie,
+	/*! [out] The cookie previously associated, if mapping is already present */
+	const void **oldcookie);
 
 /*!
  * \brief Removes a virtual directory mapping made with \b UpnpAddVirtualDir.

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -4130,7 +4130,7 @@ int UpnpSetWebServerRootDir(const char *rootDir)
 #endif /* INTERNAL_WEB_SERVER */
 
 
-int UpnpAddVirtualDir(const char *newDirName)
+int UpnpAddVirtualDir(const char *newDirName, const void *cookie, const void **oldcookie)
 {
     virtualDirList *pNewVirtualDir;
     virtualDirList *pLast;
@@ -4162,6 +4162,9 @@ int UpnpAddVirtualDir(const char *newDirName)
     while( pCurVirtualDir != NULL ) {
 	/* already has this entry */
 	if( strcmp( pCurVirtualDir->dirName, dirName ) == 0 ) {
+            if (oldcookie != NULL)
+                *oldcookie = pCurVirtualDir->cookie;
+            pCurVirtualDir->cookie = cookie;
 	    return UPNP_E_SUCCESS;
 	}
 
@@ -4174,6 +4177,9 @@ int UpnpAddVirtualDir(const char *newDirName)
 	return UPNP_E_OUTOF_MEMORY;
     }
     pNewVirtualDir->next = NULL;
+    if (oldcookie != NULL)
+        *oldcookie = NULL;
+    pNewVirtualDir->cookie = cookie;
     memset( pNewVirtualDir->dirName, 0, sizeof( pNewVirtualDir->dirName ) );
     strncpy( pNewVirtualDir->dirName, dirName,
 	sizeof( pNewVirtualDir->dirName ) - 1);

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -482,7 +482,7 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 			/* file name */
 			filename = va_arg(argp, char *);
 			if (Instr && Instr->IsVirtualFile)
-				Fp = (virtualDirCallback.open)(filename, UPNP_READ);
+				Fp = (virtualDirCallback.open)(filename, UPNP_READ, Instr->Cookie);
 			else
 				Fp = fopen(filename, "rb");
 			if (Fp == NULL) {
@@ -491,7 +491,7 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 			}
 			if (Instr && Instr->IsRangeActive && Instr->IsVirtualFile) {
 				if (virtualDirCallback.seek(Fp, Instr->RangeOffset,
-				    SEEK_CUR) != 0) {
+				    SEEK_CUR, Instr->Cookie) != 0) {
 					RetVal = UPNP_E_FILE_READ_ERROR;
 					goto Cleanup_File;
 				}
@@ -507,7 +507,7 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 					size_t n = amount_to_be_read >= Data_Buf_Size ?
 					    	Data_Buf_Size : amount_to_be_read;
 					if (Instr->IsVirtualFile) {
-						nr = virtualDirCallback.read(Fp, file_buf, n);
+						nr = virtualDirCallback.read(Fp, file_buf, n, Instr->Cookie);
 						num_read = (size_t)nr;
 					} else {
 						num_read = fread(file_buf, (size_t)1, n, Fp);
@@ -577,7 +577,7 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 			} /* while */
 Cleanup_File:
 			if (Instr && Instr->IsVirtualFile) {
-				virtualDirCallback.close(Fp);
+				virtualDirCallback.close(Fp, Instr->Cookie);
 			} else {
 				fclose(Fp);
 			}

--- a/upnp/src/inc/VirtualDir.h
+++ b/upnp/src/inc/VirtualDir.h
@@ -61,6 +61,7 @@ struct VirtualDirCallbacks
 typedef struct virtual_Dir_List
 {
 	struct virtual_Dir_List *next;
+	const void *cookie;
 	char dirName[NAME_SIZE];
 } virtualDirList;
 

--- a/upnp/src/inc/webserver.h
+++ b/upnp/src/inc/webserver.h
@@ -54,6 +54,8 @@ struct SendInstruction
 	off_t ReadSendSize;
 	/*! Recv from the network and write into local file. */
 	long RecvWriteSize;
+	/*! Cookie associated with the virtualDir. */
+	const void *Cookie;
 	/* Later few more member could be added depending
 	 * on the requirement.*/
 };


### PR DESCRIPTION
As with the main Device APIs (UpnpRegisterRootDevice etc), it is useful to
have a userdata/cookie pointer returned with each callback.

This patch allows one cookie per registered path which enables a variety of
functionality in client apps