### PR TITLE
Fix segmentation fault in http_MakeMessage

### DIFF
--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -1662,14 +1662,16 @@ int http_MakeMessage(membuffer *buf, int http_major_version,
 			struct Extra_Headers *extras;
 			/* array of extra headers */
 			extras = (struct Extra_Headers *) va_arg(argp, struct Extra_Headers *);
-			while (extras->name) {
-				if (extras->resp) {
-					if (membuffer_append(buf, extras->resp, strlen(extras->resp)))
-						goto error_handler;
-					if (membuffer_append(buf, "\r\n", (size_t)2))
-						goto error_handler;
+			if (extras) {
+				while (extras->name) {
+					if (extras->resp) {
+						if (membuffer_append(buf, extras->resp, strlen(extras->resp)))
+							goto error_handler;
+						if (membuffer_append(buf, "\r\n", (size_t)2))
+							goto error_handler;
+					}
+					extras++;
 				}
-				extras++;
 			}
 		}
 		if (c == 's') {


### PR DESCRIPTION
When upmpdcli is linked with libupnp 1.6.24 it aborts with an segmentation fault, but linking with libupnp workes just fine.

git bisect shows that commit 9c2e8ec8a0291ebe81959009e2f78edbdb47ced5 is the bad one as the variable `extras` is not properly checked before attempting to used it as a pointer.

Asure `extras` is not Null before using it.