### PR TITLE
libupnp.pc: drop -pthread from Cflags

### DIFF
--- a/libupnp.pc.in
+++ b/libupnp.pc.in
@@ -7,5 +7,5 @@ Name: libupnp
 Description: Linux SDK for UPnP Devices
 Version: @VERSION@
 Libs: @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ -L${libdir} -lupnp -lthreadutil -lixml 
-Cflags: @PTHREAD_CFLAGS@ -I${includedir}/upnp
+Cflags: -I${includedir}/upnp
 


### PR DESCRIPTION
while discussing with MPD upstream it was pointed out that `-pthread` isn't necessary in the output of `pkg-config --cflags libupnp`. 

Other than that it strikes me that `@PTHREAD_CFLAGS@` is used in the `Libs:` line and I wonder if this is correct. (For static linking `-pthread` is needed even for single threaded consumers. And it seems it doesn't need to be at the end to get it in the right linking order while the order of `-lupnp -lthreadutil -lixml` matters.) Will think about this for a while ...