### PR TITLE
Fix assertion error when http_MakeMessage is called with E in fmt

### DIFF
--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -1673,8 +1673,7 @@ int http_MakeMessage(membuffer *buf, int http_major_version,
 					extras++;
 				}
 			}
-		}
-		if (c == 's') {
+		} else if (c == 's') {
 			/* C string */
 			s = (char *)va_arg(argp, char *);
 			assert(s);


### PR DESCRIPTION
@philippe44

An assert(0) is hit if fmt contains a char that is not expected. Support
for 'E' was added without making sure that this assert isn't reached.
This only hurts in debug builds and so shows that nobody tests these :-)

Fixes: 9c2e8ec8a029 ("extra headers")
Reported-by: Tobias Frost <tobi@coldtobi.de>