### PR TITLE
Ensure there are no uncommitted changes when creating tar balls

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -64,3 +64,6 @@ endif
 
 CLEANFILES = IUpnpErrFile.txt IUpnpInfoFile.txt
 
+dist-hook:
+	# Ensure that the working copy is clean
+	test ! -d $(top_srcdir)/.git || cd $(top_srcdir) && git diff-index --quiet HEAD


### PR DESCRIPTION
Given that the .tar.bz2 provided on sf.net has some local changes introduce a check to the dist
target that makes this a tad harder.