### PR TITLE
Fix handling of http header processing for better operability with Samsung DTVs

### DIFF
--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -1455,7 +1455,7 @@ int http_SendStatusResponse(IN SOCKINFO *info, IN int http_status_code,
 	membuffer_init(&membuf);
 	membuf.size_inc = (size_t)70;
 	/* response start line */
-	ret = http_MakeMessage(&membuf, response_major, response_minor, "RSCB",
+	ret = http_MakeMessage(&membuf, response_major, response_minor, "RSCBcc",
 			       http_status_code, http_status_code);
 	if (ret == 0) {
 		timeout = HTTP_DEFAULT_TIMEOUT;
@@ -1596,9 +1596,12 @@ int http_MakeMessage(membuffer *buf, int http_major_version,
 			    (http_major_version == 1 && http_minor_version == 1)
 			    ) {
 				/* connection header */
-				if (membuffer_append_str(buf, "CONNECTION: close\r\n"))
+				if (membuffer_append_str(buf, "CONNECTION: close"))
 					goto error_handler;
 			}
+			/* append \r\n in all cases, e.g. HTTP/1.0 */
+			if (membuffer_append_str(buf, "\r\n"))
+				goto error_handler;
 		} else if (c == 'N') {
 			/* content-length header */
 			bignum = (off_t) va_arg(argp, off_t);


### PR DESCRIPTION
Many Samsung DTVs will not recognize UPnP/DLNA media servers, because they are picky about HTTP imlementation. E.g. they loop until double CRLF is found after HTTP header. If not found, then there is no processing done. -> connection failed.

A snippet out of B series TV:

`
.text:0145DCF0 0A 00 A0 E1 MOV R0, R10 ; haystack
.text:0145DCF4 E8 12 9F E5 LDR R1, =asc_215F5E0 ; "\r\n\r\n"
.text:0145DCF8 52 4C C3 EB BL strstr
.text:0145DCFC 00 00 50 E3 CMP R0, #0
.text:0145DD00 E1 FF FF 0A BEQ loc_145DC8C ; loop until EOF found
.text:0145DD04 0A 00 A0 E1 MOV R0, R10
.text:0145DD08 1F FF FF EB BL _Z15cpParseHTTPRespPc ; cpParseHTTPResp(char *)

`

In addition they send "HTTP/1.0" requests, which need to be handled properly, too.

The proposed patch fixes mentioned issues.

The patch was discussed here:
https://github.com/gerbera/gerbera/issues/111
