### PR TITLE
HTTP request line parsing: no method implies no host:port. Fixes issue #82

### DIFF
--- a/upnp/src/genlib/net/uri/uri.c
+++ b/upnp/src/genlib/net/uri/uri.c
@@ -720,7 +720,8 @@ int parse_uri(const char *in, size_t max, uri_type *out)
 		out->type = RELATIVE;
 		out->path_type = REL_PATH;
 	}
-	if (begin_hostport + (size_t)1 < max &&
+	if (out->scheme.size > 0 &&
+            begin_hostport + (size_t)1 < max &&
 	    in[begin_hostport] == '/' &&
 	    in[begin_hostport + (size_t)1] == '/') {
 		begin_hostport += (size_t)2;


### PR DESCRIPTION
Please note that this is only a tentative fix and request for discussion. I was never able to make complete sense of the HTTP and URI RFCs :)

The change does fix the problem listed in issue 82, but the requests in question are questionable.

According to RFC 1945 paragraph 5.1.2, an absolute URI is only possible if the server is a proxy. Also an absolute URI would imply a scheme part ? So the URI in the request is an abs_path which is a relative reference and can't begin with //, both from the definition in RFC 1945, and because RFC 3986 paragraph 4.2 assigns a meaning to //path, which should define an 'authority' part:

    relative-part = "//" authority path-abempty
    A relative reference that begins with two slash characters is termed a network-path reference; 
    such references are rarely used.

From a bit of testing around, it seems that some HTTP servers do refuse the double-slash, and some accept it (apache, for exemple,  seems to be ok with it).

My feeling is that libupnp should be lenient about these requests, and forget about supporting the "rarely used network-path references", which would allow to relax the syntax on the URI and treat // as /, but I have no firm opinion on the subject.

The suggested fix treats the URL as beginning with a regular path if there is no scheme present.
