### PR TITLE
Ensure that the samples use the same largefile options as the library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,8 @@ m4/lt~obsolete.m4
 stamp-h1
 upnp/inc/stamp-h2
 upnp/inc/upnpconfig.h
+upnp/sample/common/config_sample.h
+upnp/sample/common/stamp-h3
 upnp/sample/tv_combo
 upnp/sample/tv_combo-1.8
 upnp/sample/tv_ctrlpt

--- a/configure.ac
+++ b/configure.ac
@@ -432,7 +432,7 @@ AC_CANONICAL_HOST
 #    libraries : it contains information on the configuration of the
 #    installed libraries.
 #
-AC_CONFIG_HEADERS([autoconfig.h upnp/inc/upnpconfig.h])
+AC_CONFIG_HEADERS([autoconfig.h upnp/inc/upnpconfig.h upnp/sample/common/config_sample.h])
 AX_SYS_LARGEFILE_SENSITIVE
 
 if test "x$ac_cv_sys_largefile_sensitive" = "xyes"; then

--- a/upnp/sample/common/config_sample.h.in
+++ b/upnp/sample/common/config_sample.h.in
@@ -1,0 +1,21 @@
+/*
+ * On systems where the size of off_t depends on compile flags, libupnp needs
+ * the programs which use it to be built with the same options as itself.
+ * This is checked at compile time, but the actual variables (such as
+ * _FILE_OFFSET_BITS) are not exported by the library (to avoid surprises in
+ * applications).
+ * A "normal" application would need to explicitely configure large file
+ * support depending on how libupnp was built, using its own configure
+ * routines. For the samples, we equivalently let the main libupnp configure
+ * create this file.
+ */
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#undef _FILE_OFFSET_BITS
+
+/* Define to 1 to make fseeko visible on some hosts (e.g. glibc 2.2). */
+#undef _LARGEFILE_SOURCE
+
+/* Define for large files, on AIX-style hosts. */
+#undef _LARGE_FILES
+

--- a/upnp/sample/common/sample_util.h
+++ b/upnp/sample/common/sample_util.h
@@ -44,6 +44,7 @@
 extern "C" {
 #endif /* __cplusplus */
 
+#include "config_sample.h"
 #include "ithread.h"
 #include "ixml.h" /* for IXML_Document, IXML_Element */
 #include "upnp.h" /* for Upnp_EventType */


### PR DESCRIPTION
Create a configuration file specific to the samples, to mimick what a
regular application would have to do.

Fixes #94 