### PR TITLE
Clean up the log module.

### DIFF
--- a/upnp/Makefile.am
+++ b/upnp/Makefile.am
@@ -198,10 +198,11 @@ libupnp_la_SOURCES += \
 
 
 # check / distcheck tests
-check_PROGRAMS = test_init test_url
-TESTS = test_init test_url
+check_PROGRAMS = test_init test_url test_log
+TESTS = test_init test_url test_log
 test_init_SOURCES = test/test_init.c
 test_url_SOURCES = test/test_url.c
+test_log_SOURCES = test/test_log.c
 
 
 EXTRA_DIST = \

--- a/upnp/inc/upnpdebug.h
+++ b/upnp/inc/upnpdebug.h
@@ -58,13 +58,12 @@ extern "C" {
  *  The critical level will show only those messages 
  *  which can halt the normal processing of the library, like memory 
  *  allocation errors. The remaining three levels are just for debugging 
- *  purposes.  Packet level will display all the incoming and outgoing 
- *  packets that are flowing between the control point and the device. 
+ *  purposes. Error will show recoverable errors.
  *  Info Level displays the other important operational information 
  *  regarding the working of the library. If the user selects All, 
  *  then the library displays all the debugging information that it has.
  *    \li \c UPNP_CRITICAL [0]
- *    \li \c UPNP_PACKET [1]
+ *    \li \c UPNP_ERROR [1]
  *    \li \c UPNP_INFO [2]
  *    \li \c UPNP_ALL [3]
  */
@@ -82,11 +81,18 @@ typedef enum Upnp_Module {
 /*@{*/
 typedef enum Upnp_LogLevel_e {
 	UPNP_CRITICAL,
-	UPNP_PACKET,
+	UPNP_ERROR,
 	UPNP_INFO,
 	UPNP_ALL
 } Upnp_LogLevel;
 /*@}*/
+
+/* UPNP_PACKET probably resulted from a confusion between module and
+   level and was only used by a few messages in ssdp_device.c (they
+   have been moved to INFO). Kept for compatibility, don't use for new
+   messages.
+*/
+#define UPNP_PACKET UPNP_ERROR
 
 /*!
  * Default log level : see \c Upnp_LogLevel
@@ -133,21 +139,23 @@ static UPNP_INLINE void UpnpCloseLog(void)
 #endif
 
 /*!
- * \brief Set the name for error and information files, respectively.
+ * \brief Set the name for the log file. There used to be 2 separate files. The
+ * second parameter has been kept for compatibility but is ignored.
+ * Use a NULL file name for logging to stderr.
  */
 #ifdef DEBUG
 void UpnpSetLogFileNames(
-	/*! [in] Name of the error file. */
-	const char *ErrFileName,
-	/*! [in] Name of the information file. */
-	const char *InfoFileName);
+	/*! [in] Name of the log file. */
+	const char *fileName,
+	/*! [in] Ignored. */
+	const char *Ignored);
 #else
 static UPNP_INLINE void UpnpSetLogFileNames(const char *ErrFileName,
-	const char *InfoFileName)
+	const char *ignored)
 {
 	return;
 	ErrFileName = ErrFileName;
-	InfoFileName = InfoFileName;
+	ignored = ignored;
 }
 #endif
 
@@ -155,8 +163,8 @@ static UPNP_INLINE void UpnpSetLogFileNames(const char *ErrFileName,
  * \brief Check if the module is turned on for debug and returns the file
  * descriptor corresponding to the debug level
  *
- * \return NULL if the module is turn off for debug otheriwse returns the
- *	right file descriptor.
+ * \return NULL if the module is turn off for debug otherwise returns the
+ *	right FILE pointer.
  */
 #ifdef DEBUG
 FILE *UpnpGetDebugFile(
@@ -171,27 +179,6 @@ static UPNP_INLINE FILE *UpnpGetDebugFile(Upnp_LogLevel level, Dbg_Module module
 	return NULL;
 	level = level;
 	module = module;
-}
-#endif
-
-/*!
- * \brief Returns true if debug output should be done in this module.
- *
- * \return Nonzero value if true, zero if false.
- */
-#ifdef DEBUG
-int DebugAtThisLevel(
-	/*! [in] The level of the debug logging. It will decide whether debug
-	 * statement will go to standard output, or any of the log files. */
-	Upnp_LogLevel DLevel,
-	/*! [in] Debug will go in the name of this module. */
-	Dbg_Module Module);
-#else
-static UPNP_INLINE int DebugAtThisLevel(Upnp_LogLevel DLevel, Dbg_Module Module)
-{
-	return 0;
-	DLevel = DLevel;
-	Module = Module;
 }
 #endif
 
@@ -233,56 +220,6 @@ static UPNP_INLINE void UpnpPrintf(Upnp_LogLevel DLevel, Dbg_Module Module,
 }
 #endif /* DEBUG */
 
-/*!
- * \brief Writes the file name and file number from where debug statement is
- * coming to the log file.
- */
-#ifdef DEBUG
-void UpnpDisplayFileAndLine(
-	/*! [in] File descriptor where line number and file name will be
-	 * written. */
-	FILE * fd,
-	/*! [in] Name of the file. */
-	const char *DbgFileName,
-	/*! [in] Line number of the file. */
-	int DbgLineNo);
-#else
-static UPNP_INLINE void UpnpDisplayFileAndLine(FILE *fd,
-	const char *DbgFileName, int DbgLineNo)
-{
-	return;
-	fd = fd;
-	DbgFileName = DbgFileName;
-	DbgLineNo = DbgLineNo;
-}
-#endif
-
-/*!
- * \brief Writes the buffer in the file as per the requested banner
- */
-#ifdef DEBUG
-void UpnpDisplayBanner(
-	/*! [in] file descriptor where the banner will be written. */
-	FILE * fd,
-	/*! [in] The buffer that will be written. */
-	const char **lines,
-	/*! [in] Size of the buffer. */
-	size_t size,
-	/*! [in] This parameter provides the width of the banner. */
-	size_t starlength);
-#else
-static UPNP_INLINE void UpnpDisplayBanner(FILE *fd, const char **lines,
-	size_t size, int starlength)
-{
-	return;
-	fd = fd;
-	lines = lines;
-	size = size;
-	starlength = starlength;
-}
-#endif
-
-/*@}*/
 
 #ifdef __cplusplus
 }

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -3903,14 +3903,14 @@ Upnp_Handle_Type GetHandleInfo(
 {
 	Upnp_Handle_Type ret = HND_INVALID;
 
-	UpnpPrintf( UPNP_INFO, API, __FILE__, __LINE__,
+	UpnpPrintf( UPNP_ALL, API, __FILE__, __LINE__,
 		"GetHandleInfo: entering, Handle is %d\n", Hnd);
 
 	if (Hnd < 1 || Hnd >= NUM_HANDLE) {
-		UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__,
+		UpnpPrintf(UPNP_ALL, API, __FILE__, __LINE__,
 			"GetHandleInfo: Handle out of range\n");
 	} else if (HandleTable[Hnd] == NULL) {
-		UpnpPrintf(UPNP_CRITICAL, API, __FILE__, __LINE__,
+		UpnpPrintf(UPNP_ALL, API, __FILE__, __LINE__,
 			"GetHandleInfo: HandleTable[%d] is NULL\n",
 			Hnd);
 	} else if (HandleTable[Hnd] != NULL) {

--- a/upnp/src/api/upnpdebug.c
+++ b/upnp/src/api/upnpdebug.c
@@ -48,36 +48,53 @@
 
 #ifdef DEBUG
 
-/*! Mutex to synchronize all the log file opeartions in the debug mode */
+/*! Mutex to synchronize all the log file operations in the debug mode */
 static ithread_mutex_t GlobalDebugMutex;
 
 /*! Global log level */
 static Upnp_LogLevel g_log_level = UPNP_DEFAULT_LOG_LEVEL;
 
-/*! File handle for the error log file */
-static FILE *ErrFileHnd = NULL;
+/* Output file pointer */
+static FILE *fp;
+static int is_stderr;
 
-/*! File handle for the information log file */
-static FILE *InfoFileHnd = NULL;
+/* Set if the user called setlogfilename() or setloglevel() */
+static int setlogwascalled;
+static int initwascalled;
+/* Name of the output file. We keep a copy */
+static char *fileName;
 
-/*! Name of the error file */
-static const char *errFileName = "libupnp_err.log";
-
-/*! Name of the info file */
-static const char *infoFileName = "libupnp_info.log";
-
+/* This is called from UpnpInit(). So the user must call setLogFileName() 
+ * before. This can be called again, for example to rotate the log
+ * file, and we try to avoid multiple calls to the mutex init, with a
+ * risk of race, probably not a problem, and not worth fixing. */
 int UpnpInitLog(void)
 {
-	ithread_mutex_init(&GlobalDebugMutex, NULL);
-	if (DEBUG_TARGET == 1) {
-		if ((ErrFileHnd = fopen(errFileName, "a")) == NULL) {
-			fprintf(stderr, "Failed to open errFileName (%s): %s\n", errFileName, strerror(errno));
-			ErrFileHnd = stderr;
+	if (!initwascalled) {
+		ithread_mutex_init(&GlobalDebugMutex, NULL);
+		initwascalled = 1;
+	}
+	/* If the user did not ask for logging do nothing */
+	if (setlogwascalled == 0) {
+		return UPNP_E_SUCCESS;
+	}
+
+	if (fp) {
+		if (is_stderr == 0) {
+			fclose(fp);
+			fp = NULL;
 		}
-		if ((InfoFileHnd = fopen(infoFileName, "a")) == NULL) {
-			fprintf(stderr, "Failed to open infoFileName (%s): %s\n", infoFileName, strerror(errno));
-			InfoFileHnd = stdout;
+	}
+	is_stderr = 0;
+	if (fileName) {
+		if ((fp = fopen(fileName, "a")) == NULL) {
+			fprintf(stderr, "Failed to open fileName (%s): %s\n",
+					fileName, strerror(errno));
 		}
+	}
+	if (fp == NULL) {
+		fp = stderr;
+		is_stderr = 1;
 	}
 	return UPNP_E_SUCCESS;
 }
@@ -85,110 +102,138 @@ int UpnpInitLog(void)
 void UpnpSetLogLevel(Upnp_LogLevel log_level)
 {
 	g_log_level = log_level;
+	setlogwascalled = 1;
 }
 
 void UpnpCloseLog(void)
 {
-	if (DEBUG_TARGET == 1) {
-		fflush(ErrFileHnd);
-		fflush(InfoFileHnd);
-		fclose(ErrFileHnd);
-		fclose(InfoFileHnd);
+	/* Calling lock() assumes that someone called UpnpInitLog(), but
+	 * this is reasonable as it is called from UpnpInit(). We risk a
+	 * crash if we do this without a lock.*/
+	ithread_mutex_lock(&GlobalDebugMutex);
+
+	if (fp != NULL && is_stderr == 0) {
+		fclose(fp);
 	}
+	fp = NULL;
+	is_stderr = 0;
+	ithread_mutex_unlock(&GlobalDebugMutex);
 	ithread_mutex_destroy(&GlobalDebugMutex);
 }
 
-void UpnpSetLogFileNames(const char *ErrFileName, const char *InfoFileName)
+void UpnpSetLogFileNames(const char *newFileName, const char *ignored)
 {
-	if (ErrFileName) {
-		errFileName = ErrFileName;
+	if (fileName) {
+		free(fileName);
+		fileName = NULL;
 	}
-	if (InfoFileName) {
-		infoFileName = InfoFileName;
+	if (newFileName && *newFileName) {
+		fileName = strdup(newFileName);
 	}
+	setlogwascalled = 1;
+	return;
+	ignored = ignored;
 }
 
-int DebugAtThisLevel(Upnp_LogLevel DLevel, Dbg_Module Module)
+static int DebugAtThisLevel(Upnp_LogLevel DLevel, Dbg_Module Module)
 {
-	int ret = DLevel <= g_log_level;
-	ret &=
-	    DEBUG_ALL ||
-	    (Module == SSDP && DEBUG_SSDP) ||
-	    (Module == SOAP && DEBUG_SOAP) ||
-	    (Module == GENA && DEBUG_GENA) ||
-	    (Module == TPOOL && DEBUG_TPOOL) ||
-	    (Module == MSERV && DEBUG_MSERV) ||
-	    (Module == DOM && DEBUG_DOM) || (Module == HTTP && DEBUG_HTTP);
+	return (DLevel <= g_log_level) &&
+		(DEBUG_ALL ||
+		 (Module == SSDP && DEBUG_SSDP) ||
+		 (Module == SOAP && DEBUG_SOAP) ||
+		 (Module == GENA && DEBUG_GENA) ||
+		 (Module == TPOOL && DEBUG_TPOOL) ||
+		 (Module == MSERV && DEBUG_MSERV) ||
+		 (Module == DOM && DEBUG_DOM) || (Module == HTTP && DEBUG_HTTP));
 
-	return ret;
 	Module = Module; /* VC complains about this being unreferenced */
 }
 
-void UpnpPrintf(Upnp_LogLevel DLevel,
-		Dbg_Module Module,
-		const char *DbgFileName, int DbgLineNo, const char *FmtStr, ...)
-{
-	va_list ArgList;
-
-	if (!DebugAtThisLevel(DLevel, Module))
-		return;
-	ithread_mutex_lock(&GlobalDebugMutex);
-
-	va_start(ArgList, FmtStr);
-	if (DEBUG_TARGET) {
-		if (DbgFileName)
-			UpnpDisplayFileAndLine(stdout, DbgFileName, DbgLineNo);
-		vfprintf(stdout, FmtStr, ArgList);
-		fflush(stdout);
-	} else if (DLevel == 0) {
-		if (DbgFileName)
-			UpnpDisplayFileAndLine(ErrFileHnd, DbgFileName,
-					       DbgLineNo);
-		vfprintf(ErrFileHnd, FmtStr, ArgList);
-		fflush(ErrFileHnd);
-	} else {
-		if (DbgFileName)
-			UpnpDisplayFileAndLine(InfoFileHnd, DbgFileName,
-					       DbgLineNo);
-		vfprintf(InfoFileHnd, FmtStr, ArgList);
-		fflush(InfoFileHnd);
-	}
-	va_end(ArgList);
-	ithread_mutex_unlock(&GlobalDebugMutex);
-}
-
-FILE *GetDebugFile(Upnp_LogLevel DLevel, Dbg_Module Module)
-{
-	FILE *ret;
-
-	if (!DebugAtThisLevel(DLevel, Module))
-		ret = NULL;
-	if (DEBUG_TARGET)
-		ret = stdout;
-	else if (DLevel == 0)
-		ret = ErrFileHnd;
-	else
-		ret = InfoFileHnd;
-
-	return ret;
-}
-
-void UpnpDisplayFileAndLine(FILE *fd, const char *DbgFileName, int DbgLineNo)
+static void UpnpDisplayFileAndLine(
+	FILE *fp, const char *DbgFileName,
+	int DbgLineNo, Upnp_LogLevel DLevel, Dbg_Module Module)
 {
 	char timebuf[26];
 	time_t now = time(NULL);
 	struct tm *timeinfo;
+	char *smod;
+#if 0
+	char *slev;
+	/* Code kept around in case, but I think it's actually more convenient
+	   to display a numeric level */
+	switch (DLevel) {
+	case UPNP_CRITICAL: slev="CRI";break;
+	case UPNP_ERROR: slev="ERR";break;
+	case UPNP_INFO: slev="INF";break;
+	case UPNP_ALL: slev="ALL";break;
+	default: slev="UNK";break;
+	}
+#else
+	char slev[25];
+	snprintf(slev, 25, "%d", DLevel);
+#endif
+		
+	switch(Module) {
+	case SSDP: smod="SSDP";break;
+	case SOAP: smod="SOAP";break;
+	case GENA: smod="GENA";break;
+	case TPOOL: smod="TPOL";break;
+	case MSERV: smod="MSER";break;
+	case DOM: smod="DOM_";break;
+	case API: smod="API_";break;
+	case HTTP: smod="HTTP";break;
+	default: smod="UNKN";break;
+	}
+
 	timeinfo = localtime(&now);
 	strftime(timebuf, 26, "%Y-%m-%d %H:%M:%S", timeinfo);
 
-	fprintf(fd, "%s UPNP: Thread:0x%lX [%s:%d]: ", timebuf,
+	fprintf(fp, "%s UPNP-%s-%s: Thread:0x%lX [%s:%d]: ", timebuf, smod, slev,
 #ifdef _WIN32
 		(unsigned long int)ithread_self().p
 #else
 		(unsigned long int)ithread_self()
 #endif
 	, DbgFileName, DbgLineNo);
-	fflush(fd);
+	fflush(fp);
 }
+
+void UpnpPrintf(
+	Upnp_LogLevel DLevel, Dbg_Module Module,
+	const char *DbgFileName, int DbgLineNo, const char *FmtStr, ...)
+{
+	/*fprintf(stderr, "UpnpPrintf: fp %p level %d glev %d mod %d DEBUG_ALL %d\n",
+	  fp, DLevel, g_log_level, Module, DEBUG_ALL);*/
+	va_list ArgList;
+
+	if (!DebugAtThisLevel(DLevel, Module))
+		return;
+	ithread_mutex_lock(&GlobalDebugMutex);
+	if (fp == NULL) {
+		ithread_mutex_unlock(&GlobalDebugMutex);
+		return;
+	}
+
+	va_start(ArgList, FmtStr);
+	if (DbgFileName) {
+		UpnpDisplayFileAndLine(fp, DbgFileName, DbgLineNo, DLevel, Module);
+		vfprintf(fp, FmtStr, ArgList);
+		fflush(fp);
+	}
+	va_end(ArgList);
+	ithread_mutex_unlock(&GlobalDebugMutex);
+}
+
+/* No locking here, the app should be careful about not calling
+   closelog from a separate thread... */
+FILE *UpnpGetDebugFile(Upnp_LogLevel DLevel, Dbg_Module Module)
+{
+	if (!DebugAtThisLevel(DLevel, Module)) {
+		return	NULL;
+	} else {
+		return fp;
+	}
+}
+
 
 #endif /* DEBUG */

--- a/upnp/src/genlib/net/http/httpparser.c
+++ b/upnp/src/genlib/net/http/httpparser.c
@@ -2198,35 +2198,37 @@ const char *method_to_str(IN http_method_t method)
 #ifdef DEBUG
 void print_http_headers(http_message_t *hmsg)
 {
-
 	ListNode *node;
-	/* NNS:  dlist_node *node; */
+	/* NNS:	 dlist_node *node; */
 	http_header_t *header;
 
-    /* print start line */
-    if( hmsg->is_request ) {
-	printf( "method = %d, version = %d.%d, url = %.*s\n",
-			hmsg->method, hmsg->major_version, hmsg->minor_version,
-	    (int)hmsg->uri.pathquery.size, hmsg->uri.pathquery.buff);
-    } else {
-	printf( "resp status = %d, version = %d.%d, status msg = %.*s\n",
-	    hmsg->status_code, hmsg->major_version, hmsg->minor_version,
-	    (int)hmsg->status_msg.length, hmsg->status_msg.buf);
-    }
+	/* print start line */
+	if( hmsg->is_request ) {
+		UpnpPrintf(UPNP_ALL, HTTP, __FILE__, __LINE__,
+				   "method = %d, version = %d.%d, url = %.*s\n",
+				   hmsg->method, hmsg->major_version, hmsg->minor_version,
+				   (int)hmsg->uri.pathquery.size, hmsg->uri.pathquery.buff);
+	} else {
+		UpnpPrintf(UPNP_ALL, HTTP, __FILE__, __LINE__,
+				   "resp status = %d, version = %d.%d, status msg = %.*s\n",
+				   hmsg->status_code, hmsg->major_version, hmsg->minor_version,
+				   (int)hmsg->status_msg.length, hmsg->status_msg.buf);
+	}
 
-    /* print headers */
-    node = ListHead( &hmsg->headers );
-    /* NNS: node = dlist_first_node( &hmsg->headers ); */
-    while( node != NULL ) {
-	header = ( http_header_t * ) node->item;
-	/* NNS: header = (http_header_t *)node->data; */
-	printf( "hdr name: %.*s, value: %.*s\n",
-	    (int)header->name.length, header->name.buf,
-	    (int)header->value.length, header->value.buf );
+	/* print headers */
+	node = ListHead( &hmsg->headers );
+	/* NNS: node = dlist_first_node( &hmsg->headers ); */
+	while( node != NULL ) {
+		header = ( http_header_t * ) node->item;
+		/* NNS: header = (http_header_t *)node->data; */
+		UpnpPrintf(UPNP_ALL, HTTP, __FILE__, __LINE__,
+				   "hdr name: %.*s, value: %.*s\n",
+				   (int)header->name.length, header->name.buf,
+				   (int)header->value.length, header->value.buf );
 
-	node = ListNext( &hmsg->headers, node );
-	/* NNS: node = dlist_next( &hmsg->headers, node ); */
-    }
+		node = ListNext( &hmsg->headers, node );
+		/* NNS: node = dlist_next( &hmsg->headers, node ); */
+	}
 }
 #endif /* DEBUG */
 

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -555,7 +555,7 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 					       strlen(Chunk_Header));
 					/* on the top of the buffer. */
 					/*file_buf[num_read+strlen(Chunk_Header)] = NULL; */
-					/*printf("Sending %s\n",file_buf-strlen(Chunk_Header)); */
+					/*upnpprintf("Sending %s\n",file_buf-strlen(Chunk_Header));*/
 					nw = sock_write(info,
 						file_buf - strlen(Chunk_Header),
 						num_read + strlen(Chunk_Header) + (size_t)2,

--- a/upnp/src/genlib/net/uri/uri.c
+++ b/upnp/src/genlib/net/uri/uri.c
@@ -261,7 +261,8 @@ void free_URL_list(URL_list *list)
 }
 
 
-#ifdef DEBUG
+/* This should use upnpdebug. Failing that, disable by default */
+#ifdef DEBUG_URI
 void print_uri(uri_type *in)
 {
 	print_token(&in->scheme);
@@ -269,15 +270,12 @@ void print_uri(uri_type *in)
 	print_token(&in->pathquery);
 	print_token(&in->fragment);
 }
-#endif /* DEBUG */
 
-
-#ifdef DEBUG
 void print_token(token * in)
 {
 	size_t i = 0;
 
-	printf("Token Size : %" PRIzu "\n\'", in->size);
+	fprintf(stderr, "Token Size : %" PRIzu "\n\'", in->size);
 	for (i = 0; i < in->size; i++)
 		putchar(in->buff[i]);
 	putchar('\'');

--- a/upnp/src/ssdp/ssdp_device.c
+++ b/upnp/src/ssdp/ssdp_device.c
@@ -131,15 +131,15 @@ void ssdp_handle_device_request(http_message_t *hmsg, struct sockaddr_storage *d
 		maxAge = dev_info->MaxAge;
 		HandleUnlock();
 
-		UpnpPrintf(UPNP_PACKET, API, __FILE__, __LINE__,
+		UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__,
 				   "MAX-AGE     =  %d\n", maxAge);
-		UpnpPrintf(UPNP_PACKET, API, __FILE__, __LINE__,
+		UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__,
 				   "MX     =  %d\n", event.Mx);
-		UpnpPrintf(UPNP_PACKET, API, __FILE__, __LINE__,
+		UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__,
 				   "DeviceType   =  %s\n", event.DeviceType);
-		UpnpPrintf(UPNP_PACKET, API, __FILE__, __LINE__,
+		UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__,
 				   "DeviceUuid   =  %s\n", event.UDN);
-		UpnpPrintf(UPNP_PACKET, API, __FILE__, __LINE__,
+		UpnpPrintf(UPNP_INFO, API, __FILE__, __LINE__,
 				   "ServiceType =  %s\n", event.ServiceType);
 		threadArg = (SsdpSearchReply *)malloc(sizeof(SsdpSearchReply));
 		if (threadArg == NULL)

--- a/upnp/src/threadutil/ThreadPool.c
+++ b/upnp/src/threadutil/ThreadPool.c
@@ -1182,20 +1182,20 @@ void ThreadPoolPrintStats(ThreadPoolStats *stats)
 	if (!stats)
 		return;
 	/* some OSses time_t length may depending on platform, promote it to long for safety */
-	printf("ThreadPoolStats at Time: %ld\n", (long)StatsTime(NULL));
-	printf("High Jobs pending: %d\n", stats->currentJobsHQ);
-	printf("Med Jobs Pending: %d\n", stats->currentJobsMQ);
-	printf("Low Jobs Pending: %d\n", stats->currentJobsLQ);
-	printf("Average Wait in High Priority Q in milliseconds: %f\n", stats->avgWaitHQ);
-	printf("Average Wait in Med Priority Q in milliseconds: %f\n", stats->avgWaitMQ);
-	printf("Averate Wait in Low Priority Q in milliseconds: %f\n", stats->avgWaitLQ);
-	printf("Max Threads Active: %d\n", stats->maxThreads);
-	printf("Current Worker Threads: %d\n", stats->workerThreads);
-	printf("Current Persistent Threads: %d\n", stats->persistentThreads);
-	printf("Current Idle Threads: %d\n", stats->idleThreads);
-	printf("Total Threads : %d\n", stats->totalThreads);
-	printf("Total Time spent Working in seconds: %f\n", stats->totalWorkTime);
-	printf("Total Time spent Idle in seconds : %f\n", stats->totalIdleTime);
+	fprintf(stderr,"ThreadPoolStats at Time: %ld\n", (long)StatsTime(NULL));
+	fprintf(stderr,"High Jobs pending: %d\n", stats->currentJobsHQ);
+	fprintf(stderr,"Med Jobs Pending: %d\n", stats->currentJobsMQ);
+	fprintf(stderr,"Low Jobs Pending: %d\n", stats->currentJobsLQ);
+	fprintf(stderr,"Average Wait in High Priority Q in milliseconds: %f\n", stats->avgWaitHQ);
+	fprintf(stderr,"Average Wait in Med Priority Q in milliseconds: %f\n", stats->avgWaitMQ);
+	fprintf(stderr,"Averate Wait in Low Priority Q in milliseconds: %f\n", stats->avgWaitLQ);
+	fprintf(stderr,"Max Threads Active: %d\n", stats->maxThreads);
+	fprintf(stderr,"Current Worker Threads: %d\n", stats->workerThreads);
+	fprintf(stderr,"Current Persistent Threads: %d\n", stats->persistentThreads);
+	fprintf(stderr,"Current Idle Threads: %d\n", stats->idleThreads);
+	fprintf(stderr,"Total Threads : %d\n", stats->totalThreads);
+	fprintf(stderr,"Total Time spent Working in seconds: %f\n", stats->totalWorkTime);
+	fprintf(stderr,"Total Time spent Idle in seconds : %f\n", stats->totalIdleTime);
 }
 
 int ThreadPoolGetStats(ThreadPool *tp, ThreadPoolStats *stats)

--- a/upnp/test/test_log.c
+++ b/upnp/test/test_log.c
@@ -1,0 +1,82 @@
+/**************************************************************************
+ *
+ * Copyright (c) 2018 Jean-Francois Dockes <jfd@recoll.org>
+ * All rights reserved. 
+ *
+ * Redistribution and use in source and binary forms, with or without 
+ * modification, are permitted provided that the following conditions are met: 
+ *
+ * * Redistributions of source code must retain the above copyright notice, 
+ * this list of conditions and the following disclaimer. 
+ * * Redistributions in binary form must reproduce the above copyright notice, 
+ * this list of conditions and the following disclaimer in the documentation 
+ * and/or other materials provided with the distribution. 
+ * * Neither name of Intel Corporation nor the names of its contributors 
+ * may be used to endorse or promote products derived from this software 
+ * without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL OR 
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY 
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *************************************************************************/
+#include "upnp.h"
+#include "upnpconfig.h"
+#include "upnpdebug.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main (int argc, char* argv[])
+{
+#if UPNP_HAVE_DEBUG
+	/* Try a few random calls (let's crash it...) */
+	UpnpCloseLog();
+	UpnpCloseLog();
+	UpnpPrintf(UPNP_CRITICAL,API,__FILE__,__LINE__,
+			   "This should not be printed !\n");
+	FILE *fp = UpnpGetDebugFile(UPNP_CRITICAL, API);
+	if (fp) {
+		fprintf(stderr, "Log FP not NULL before init was called !\n");
+		exit(1);
+	}
+
+	/* Let's really init. Request log to stderr */
+	UpnpSetLogFileNames(NULL, NULL);
+	UpnpSetLogLevel(UPNP_ERROR);
+	UpnpInitLog();
+
+	UpnpPrintf(UPNP_CRITICAL,API,__FILE__,__LINE__,"Hello LOG !\n");
+	UpnpPrintf(UPNP_INFO,API,__FILE__,__LINE__,"This should not be here !\n");
+
+	/* Let's try to a file */
+	UpnpSetLogFileNames("libupnp_err.log", NULL);
+	UpnpInitLog();
+	UpnpPrintf(UPNP_CRITICAL,API,__FILE__,__LINE__,"Hello from the log file\n");
+
+	/* Close and retry stuff */
+	UpnpCloseLog();
+	UpnpPrintf(UPNP_INFO,API,__FILE__,__LINE__,"Not here either!\n");
+	UpnpSetLogFileNames(NULL, NULL);
+	UpnpInitLog();
+	UpnpPrintf(UPNP_CRITICAL,API,__FILE__,__LINE__,"I'm back !\n");
+	for (int i = 0; i < 10000; i++) {
+		UpnpInitLog();
+		UpnpCloseLog();
+	}
+	UpnpCloseLog();
+#else	
+	printf("DEBUG is not configured\n");
+#endif
+	
+	exit(0);
+}
+


### PR DESCRIPTION
- Create no files and write nothing by default.
- Accept any sequence of init/close/print without crashing or leaking
  resources.
- Never ever write anything to stdout, the app may use it.
- Use a single file with enough data in each message to enable filtering.
- Minimum change to the message format (add level and target), in a way
  unlikely to confuse a hypothetical existing parser.
- No change to the API, except that:
  * the 2nd file name parameter to UpnpSetLogFilenames is ignored.
  * DebugAtThisLevel is gone from the include file (not exported and not
    used internally anyway)
  * UpnpDisplayFileAndLine() and UpnpDisplayBanner() are gone.
- Also replace some fprintf() calls with upnpprintf() (httpparser.c)