### PR TITLE
Add Request level cookies to virtualdir calls

### DIFF
--- a/upnp/inc/upnp.h
+++ b/upnp/inc/upnp.h
@@ -2571,12 +2571,14 @@ typedef void *UpnpWebFileHandle;
  * \brief Get-info callback function prototype.
  */
 typedef int (*VDCallback_GetInfo)(
-		/*! [in] The name of the file to query. */
-		const char *filename,
-		/*! [out] Pointer to a structure to store the information on the file. */
-		UpnpFileInfo *info,
-		/*! [in] The cookie associated with this VirtualDir */
-		const void *cookie);
+    /*! [in] The name of the file to query. */
+    const char *filename,
+    /*! [out] Pointer to a structure to store the information on the file. */
+    UpnpFileInfo *info,
+    /*! [in] The cookie associated with this VirtualDir */
+    const void *cookie,
+    /*! [out] The cookie associated with this request */
+    const void **request_cookie);
 
 /*!
  * \brief Sets the get_info callback function to be used to access a virtual
@@ -2592,13 +2594,15 @@ EXPORT_SPEC int UpnpVirtualDir_set_GetInfoCallback(VDCallback_GetInfo callback);
  * \brief Open callback function prototype.
  */
 typedef UpnpWebFileHandle (*VDCallback_Open)(
-		/*! [in] The name of the file to open. */ 
-		const char *filename,
-		/*! [in] The mode in which to open the file.
-		 * Valid values are \c UPNP_READ or \c UPNP_WRITE. */
-		enum UpnpOpenFileMode Mode,
-		/*! [in] The cookie associated with this VirtualDir */
-		const void *cookie);
+    /*! [in] The name of the file to open. */
+    const char *filename,
+    /*! [in] The mode in which to open the file.
+     * Valid values are \c UPNP_READ or \c UPNP_WRITE. */
+    enum UpnpOpenFileMode Mode,
+    /*! [in] The cookie associated with this VirtualDir */
+    const void *cookie,
+    /*! [in] The cookie associated with this request */
+    const void *request_cookie);
 
 /*!
  * \brief Sets the open callback function to be used to access a virtual
@@ -2614,14 +2618,16 @@ EXPORT_SPEC int UpnpVirtualDir_set_OpenCallback(VDCallback_Open callback);
  * \brief Read callback function prototype.
  */
 typedef int (*VDCallback_Read)(
-	/*! [in] The handle of the file to read. */
-	UpnpWebFileHandle fileHnd,
-	/*! [out] The buffer in which to place the data. */
-	char *buf,
-	/*! [in] The size of the buffer (i.e. the number of bytes to read). */
-	size_t buflen,
-	/*! [in] The cookie associated with this VirtualDir */
-	const void *cookie);
+    /*! [in] The handle of the file to read. */
+    UpnpWebFileHandle fileHnd,
+    /*! [out] The buffer in which to place the data. */
+    char *buf,
+    /*! [in] The size of the buffer (i.e. the number of bytes to read). */
+    size_t buflen,
+    /*! [in] The cookie associated with this VirtualDir */
+    const void *cookie,
+    /*! [in] The cookie associated with this request */
+    const void *request_cookie);
 
 /*! 
  * \brief Sets the read callback function to be used to access a virtual
@@ -2637,14 +2643,16 @@ EXPORT_SPEC int UpnpVirtualDir_set_ReadCallback(VDCallback_Read callback);
  * \brief Write callback function prototype.
  */
 typedef	int (*VDCallback_Write)(
-	/*! [in] The handle of the file to write. */
-	UpnpWebFileHandle fileHnd,
-	/*! [in] The buffer with the bytes to write. */
-	char *buf,
-	/*! [in] The number of bytes to write. */
-	size_t buflen,
-	/*! [in] The cookie associated with this VirtualDir */
-	const void *cookie);
+    /*! [in] The handle of the file to write. */
+    UpnpWebFileHandle fileHnd,
+    /*! [in] The buffer with the bytes to write. */
+    char *buf,
+    /*! [in] The number of bytes to write. */
+    size_t buflen,
+    /*! [in] The cookie associated with this VirtualDir */
+    const void *cookie,
+    /*! [in] The cookie associated with this request */
+    const void *request_cookie);
 
 /*!
  * \brief Sets the write callback function to be used to access a virtual
@@ -2660,19 +2668,21 @@ EXPORT_SPEC int UpnpVirtualDir_set_WriteCallback(VDCallback_Write callback);
  * \brief Seek callback function prototype.
  */
 typedef int (*VDCallback_Seek) (
-	/*! [in] The handle of the file to move the file pointer. */
-	UpnpWebFileHandle fileHnd,
-	/*! [in] The number of bytes to move in the file.  Positive values
-	 * move foward and negative values move backward.  Note that
-	 * this must be positive if the \b origin is \c SEEK_SET. */
-	off_t offset,
-	/*! [in] The position to move relative to.  It can be \c SEEK_CUR
-	 * to move relative to the current position, \c SEEK_END to
-	 * move relative to the end of the file, or \c SEEK_SET to
-	 * specify an absolute offset. */
-	int origin,
-	/*! [in] The cookie associated with this VirtualDir */
-	const void *cookie);
+    /*! [in] The handle of the file to move the file pointer. */
+    UpnpWebFileHandle fileHnd,
+    /*! [in] The number of bytes to move in the file.  Positive values
+     * move foward and negative values move backward.  Note that
+     * this must be positive if the \b origin is \c SEEK_SET. */
+    off_t offset,
+    /*! [in] The position to move relative to.  It can be \c SEEK_CUR
+     * to move relative to the current position, \c SEEK_END to
+     * move relative to the end of the file, or \c SEEK_SET to
+     * specify an absolute offset. */
+    int origin,
+    /*! [in] The cookie associated with this VirtualDir */
+    const void *cookie,
+    /*! [in] The cookie associated with this request */
+    const void *request_cookie);
 
 /*!
  * \brief Sets the seek callback function to be used to access a virtual
@@ -2688,10 +2698,12 @@ EXPORT_SPEC int UpnpVirtualDir_set_SeekCallback(VDCallback_Seek callback);
  * \brief Close callback function prototype.
  */
 typedef int (*VDCallback_Close)(
-		/*! [in] The handle of the file to close. */
-		UpnpWebFileHandle fileHnd,
-		/*! [in] The cookie associated with this VirtualDir */
-		const void *cookie);
+    /*! [in] The handle of the file to close. */
+    UpnpWebFileHandle fileHnd,
+    /*! [in] The cookie associated with this VirtualDir */
+    const void *cookie,
+    /*! [in] The cookie associated with this request */
+    const void *request_cookie);
 
 /*!
  * \brief Sets the close callback function to be used to access a virtual

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -484,7 +484,7 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 			/* file name */
 			filename = va_arg(argp, char *);
 			if (Instr && Instr->IsVirtualFile)
-				Fp = (virtualDirCallback.open)(filename, UPNP_READ, Instr->Cookie);
+				Fp = (virtualDirCallback.open)(filename, UPNP_READ, Instr->Cookie, Instr->RequestCookie);
 			else
 				Fp = fopen(filename, "rb");
 			if (Fp == NULL) {
@@ -493,7 +493,7 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 			}
 			if (Instr && Instr->IsRangeActive && Instr->IsVirtualFile) {
 				if (virtualDirCallback.seek(Fp, Instr->RangeOffset,
-				    SEEK_CUR, Instr->Cookie) != 0) {
+					SEEK_CUR, Instr->Cookie, Instr->RequestCookie) != 0) {
 					RetVal = UPNP_E_FILE_READ_ERROR;
 					goto Cleanup_File;
 				}
@@ -509,7 +509,8 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 					size_t n = amount_to_be_read >= (off_t)Data_Buf_Size ?
 						Data_Buf_Size : (size_t)amount_to_be_read;
 					if (Instr->IsVirtualFile) {
-						nr = virtualDirCallback.read(Fp, file_buf, n, Instr->Cookie);
+						nr = virtualDirCallback.read(Fp, file_buf, n,
+							Instr->Cookie, Instr->RequestCookie);
 						num_read = (size_t)nr;
 					} else {
 						num_read = fread(file_buf, (size_t)1, n, Fp);
@@ -579,7 +580,7 @@ int http_SendMessage(SOCKINFO *info, int *TimeOut, const char *fmt, ...)
 			} /* while */
 Cleanup_File:
 			if (Instr && Instr->IsVirtualFile) {
-				virtualDirCallback.close(Fp, Instr->Cookie);
+				virtualDirCallback.close(Fp, Instr->Cookie, Instr->RequestCookie);
 			} else {
 				fclose(Fp);
 			}

--- a/upnp/src/genlib/net/http/webserver.c
+++ b/upnp/src/genlib/net/http/webserver.c
@@ -1185,7 +1185,7 @@ static int process_request(
 
 			/* get file info */
 			if (virtualDirCallback.
-			    get_info(filename->buf, finfo, RespInstr->Cookie) != 0) {
+			    get_info(filename->buf, finfo, RespInstr->Cookie, &RespInstr->RequestCookie) != 0) {
 				err_code = HTTP_NOT_FOUND;
 				goto error_handler;
 			}
@@ -1200,7 +1200,7 @@ static int process_request(
 					goto error_handler;
 				}
 				/* get info */
-				if (virtualDirCallback.get_info(filename->buf, finfo, RespInstr->Cookie) != UPNP_E_SUCCESS ||
+				if (virtualDirCallback.get_info(filename->buf, finfo, RespInstr->Cookie, &RespInstr->RequestCookie) != UPNP_E_SUCCESS ||
 				    UpnpFileInfo_get_IsDirectory(finfo)) {
 					err_code = HTTP_NOT_FOUND;
 					goto error_handler;
@@ -1433,7 +1433,7 @@ static int http_RecvPostMessage(
 	int ret_code = HTTP_OK;
 
 	if (Instr && Instr->IsVirtualFile) {
-		Fp = (virtualDirCallback.open) (filename, UPNP_WRITE, Instr->Cookie);
+		Fp = (virtualDirCallback.open) (filename, UPNP_WRITE, Instr->Cookie, Instr->RequestCookie);
 		if (Fp == NULL)
 			return HTTP_INTERNAL_SERVER_ERROR;
 	} else {
@@ -1511,7 +1511,8 @@ static int http_RecvPostMessage(
 		       Data_Buf_Size);
 		entity_offset += Data_Buf_Size;
 		if (Instr && Instr->IsVirtualFile) {
-			int n = virtualDirCallback.write(Fp, Buf, Data_Buf_Size, Instr->Cookie);
+			int n = virtualDirCallback.write(Fp, Buf, Data_Buf_Size,
+					Instr->Cookie, Instr->RequestCookie);
 			if (n < 0) {
 				ret_code = HTTP_INTERNAL_SERVER_ERROR;
 				goto ExitFunction;
@@ -1527,7 +1528,7 @@ static int http_RecvPostMessage(
 		 entity_offset != parser->msg.entity.length);
 ExitFunction:
 	if (Instr && Instr->IsVirtualFile) {
-		virtualDirCallback.close(Fp, Instr->Cookie);
+		virtualDirCallback.close(Fp, Instr->Cookie, Instr->RequestCookie);
 	} else {
 		fclose(Fp);
 	}

--- a/upnp/src/inc/httpreadwrite.h
+++ b/upnp/src/inc/httpreadwrite.h
@@ -152,7 +152,7 @@ int http_SendMessage(
 	/* [in] Socket information object. */
 	SOCKINFO *info,
 	/* [in,out] Time out value. */
-	int* timeout_secs, 
+	int* timeout_secs,
 	/* [in] Pattern format to take actions upon. */
 	const char* fmt,
 	/* [in] Variable parameter list. */

--- a/upnp/src/inc/webserver.h
+++ b/upnp/src/inc/webserver.h
@@ -56,6 +56,8 @@ struct SendInstruction
 	long RecvWriteSize;
 	/*! Cookie associated with the virtualDir. */
 	const void *Cookie;
+    /*! Cookie associated with the request. */
+    const void *RequestCookie;
 	/* Later few more member could be added depending
 	 * on the requirement.*/
 };


### PR DESCRIPTION
Currently there is no mechanism inside libupnp to track data accross the `get_info` -> `read` ->` close` flow of VirtualDir calls.

This means that client applications may have to do operations such as parsing and access checks etc twice, once in get_info, and again in read, or somehow track request lifetimes.

This change adds a new argument to the VirtualDir callbacks, so is not backwards compatible. 