### PR TITLE
Revert "fix handling of http header processing for better operability…

### DIFF
--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -1457,7 +1457,7 @@ int http_SendStatusResponse(IN SOCKINFO *info, IN int http_status_code,
 	membuffer_init(&membuf);
 	membuf.size_inc = (size_t)70;
 	/* response start line */
-	ret = http_MakeMessage(&membuf, response_major, response_minor, "RSCBcc",
+	ret = http_MakeMessage(&membuf, response_major, response_minor, "RSCB",
 			       http_status_code, http_status_code);
 	if (ret == 0) {
 		timeout = HTTP_DEFAULT_TIMEOUT;
@@ -1617,12 +1617,9 @@ int http_MakeMessage(membuffer *buf, int http_major_version,
 			    (http_major_version == 1 && http_minor_version == 1)
 			    ) {
 				/* connection header */
-				if (membuffer_append_str(buf, "CONNECTION: close"))
+				if (membuffer_append_str(buf, "CONNECTION: close\r\n"))
 					goto error_handler;
 			}
-			/* append \r\n in all cases, e.g. HTTP/1.0 */
-			if (membuffer_append_str(buf, "\r\n"))
-				goto error_handler;
 		} else if (c == 'N') {
 			/* content-length header */
 			bignum = (off_t) va_arg(argp, off_t);


### PR DESCRIPTION
… with Samsung DTVs, which require 2xCRLF after header"

This reverts commit 6d0e485b4d3e7dd6d057c84023861c5cf5f822b8.

This commit (pull request #79) arbitrarily adds a second empty line to HTTP
1.0 messages at the place where the CONNECTION: header would be if the
message was HTTP 1.1 (it leaves 1.1 messages unchanged). This breaks
standard-compliant HTTP 1.0 clients.

The second empty line is taken as part of the body: this is really basic,
and true with ALL HTTP versions, The syntax of ANY HTTP message of ANY
version:

Request or status line
Headers
Single empty-line
Body

If there is a second empty line, it is taken as part of the body. This has
two consequences:

    - If an XML document is following, there will be a blank line before
      <?xml. Some parsers don't like it.
    - As the message content-length header was not adjusted when adding the
      second cr/lf, there will be data missing at the end of the
      document. Again, for example with XML, if there was no extra white
      space after the closing tag, the document is now incomplete
      (e.g. ending with </root).

In many cases the change had no visible consequences, because the
client is using HTTP/1.1, or because the XML parser is lenient, and the
document can be truncated with no consequences (for example if there is
extra whitespace at the end).

But, for example, upnp-inspector does not discover upmpdcli instances when
run with this change, because it uses HTTP 1.0, and the XML description
document it receives lacks a closing '>'

Also: adding the spurious empty line was done as part of processing the 'C'
directive (Connection: close). There is no guarantee that this header is
the last (currently: it is always last as far as I can see). If further
headers are added, of course, they will be ignored.

This change was performed to accomodate Samsung TVs. This should be done
instead at the application level by adding an empty line in the content
itself.