### PR TITLE
configure.ac: fix build with openssl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -722,6 +722,11 @@ AC_COMPILE_IFELSE(
 			AC_MSG_ERROR([pthread_rwlock_t not available])])])
 echo "-------------------------------------------------------------------------------"
 
+if test "x$enable_open_ssl" = xyes ; then
+	PKG_CHECK_MODULES(OPENSSL, libssl,
+		[LIBS="$LIBS $OPENSSL_LIBS" CFLAGS="$CFLAGS $OPENSSL_CFLAGS"],
+		[AC_MSG_ERROR([openssl not found])])
+fi
 
 AC_CONFIG_FILES([
 	Makefile

--- a/libupnp.pc.in
+++ b/libupnp.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: libupnp
 Description: Linux SDK for UPnP Devices
 Version: @VERSION@
-Libs: @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ -L${libdir} -lupnp -lixml
+Libs: @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ -L${libdir} -lupnp -lixml @OPENSSL_LIBS@
 Cflags: @PTHREAD_CFLAGS@ -I${includedir}/upnp
 


### PR DESCRIPTION
- Add a call to PKG_CHECK_MODULES to get openssl libraries and its
  dependencies if openssl support is enabled
- Add OPENSSL_LIBS to libupnp.pc.in so that applications linking with
  pupnp (such as mpd) will be able to retrieve openssl libraries

Fixes:
 - http://autobuild.buildroot.org/results/a4148e516070b79816769f3443fc24d6d8192073

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>