### PR TITLE
libupnp.pc.in: move openssl in Libs.private

### DIFF
--- a/libupnp.pc.in
+++ b/libupnp.pc.in
@@ -6,6 +6,7 @@ includedir=@includedir@
 Name: libupnp
 Description: Linux SDK for UPnP Devices
 Version: @VERSION@
-Libs: @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ -L${libdir} -lupnp -lixml @OPENSSL_LIBS@
+Libs: @PTHREAD_CFLAGS@ @PTHREAD_LIBS@ -L${libdir} -lupnp -lixml
+Libs.private: @OPENSSL_LIBS@
 Cflags: @PTHREAD_CFLAGS@ -I${includedir}/upnp
 


### PR DESCRIPTION
openssl is a private library so move it from Libs to Libs.private
in libupnp.pc.in

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>