### PR TITLE
fix off-by-one overread on global variable

### DIFF
--- a/ixml/src/ixmlparser.c
+++ b/ixml/src/ixmlparser.c
@@ -671,7 +671,7 @@ static BOOL Parser_isCharInTable(
 	int sz)
 {
 	int t = 0;
-	int b = sz;
+	int b = sz - 1;
 	int m;
 
 	while (t <= b) {


### PR DESCRIPTION
when c is large enough, m can become equal to sz (found with AFL).