### PR TITLE
upnp/sample: Use UpnpResolveURL2 in samples

### DIFF
--- a/upnp/sample/common/sample_util.c
+++ b/upnp/sample/common/sample_util.c
@@ -601,20 +601,14 @@ int SampleUtil_FindAndParseService(IXML_Document *DescDoc, const char *location,
 				SampleUtil_Print("serviceId: %s\n", *serviceId);
 				relcontrolURL = SampleUtil_GetFirstElementItem(service, "controlURL");
 				releventURL = SampleUtil_GetFirstElementItem(service, "eventSubURL");
-				*controlURL = malloc(strlen(base) + strlen(relcontrolURL) + 1);
-				if (*controlURL) {
-					ret = UpnpResolveURL(base, relcontrolURL, *controlURL);
-					if (ret != UPNP_E_SUCCESS)
-						SampleUtil_Print("Error generating controlURL from %s + %s\n",
-							base, relcontrolURL);
-				}
-				*eventURL = malloc(strlen(base) + strlen(releventURL) + 1);
-				if (*eventURL) {
-					ret = UpnpResolveURL(base, releventURL, *eventURL);
-					if (ret != UPNP_E_SUCCESS)
-						SampleUtil_Print("Error generating eventURL from %s + %s\n",
-							base, releventURL);
-				}
+				ret = UpnpResolveURL2(base, relcontrolURL, controlURL);
+				if (ret != UPNP_E_SUCCESS)
+					SampleUtil_Print("Error generating controlURL from %s + %s\n",
+							 base, relcontrolURL);
+				ret = UpnpResolveURL2(base, releventURL, eventURL);
+				if (ret != UPNP_E_SUCCESS)
+					SampleUtil_Print("Error generating eventURL from %s + %s\n",
+							 base, releventURL);
 				free(relcontrolURL);
 				free(releventURL);
 				relcontrolURL = NULL;

--- a/upnp/sample/common/tv_ctrlpt.c
+++ b/upnp/sample/common/tv_ctrlpt.c
@@ -648,7 +648,7 @@ void TvCtrlPointAddDevice(
 {
 	char *deviceType = NULL;
 	char *friendlyName = NULL;
-	char presURL[200];
+	char *presURL = NULL;
 	char *baseURL = NULL;
 	char *relURL = NULL;
 	char *UDN = NULL;
@@ -676,7 +676,7 @@ void TvCtrlPointAddDevice(
 	baseURL = SampleUtil_GetFirstDocumentItem(DescDoc, "URLBase");
 	relURL = SampleUtil_GetFirstDocumentItem(DescDoc, "presentationURL");
 
-	ret = UpnpResolveURL((baseURL ? baseURL : location), relURL, presURL);
+	ret = UpnpResolveURL2((baseURL ? baseURL : location), relURL, &presURL);
 
 	if (UPNP_E_SUCCESS != ret)
 		SampleUtil_Print("Error generating presURL from %s + %s\n",
@@ -798,6 +798,8 @@ void TvCtrlPointAddDevice(
 		free(baseURL);
 	if (relURL)
 		free(relURL);
+	if (presURL)
+		free(presURL);
 	for (service = 0; service < TV_SERVICE_SERVCOUNT; service++) {
 		if (serviceId[service])
 			free(serviceId[service]);


### PR DESCRIPTION
UpnpResolveURL is a tricky API to use correctly and the samples
allocate one bytes less than strictly required. This code has
been copied into other applications that similarly have problems
alocating the correct amount of space. Fortunately UpnpResolveURL2
is available and it avoids the need to allocate space in the caller
and does less copying too.