### PR TITLE
Always fully initialize struct SendInstruction. Fix indentation in webserver.h

### DIFF
--- a/upnp/src/genlib/net/http/webserver.c
+++ b/upnp/src/genlib/net/http/webserver.c
@@ -1547,14 +1547,8 @@ void web_server_callback(http_parser_t *parser, INOUT http_message_t *req,
 	struct xml_alias_t xmldoc;
 	struct SendInstruction RespInstr;
 
-	/*Initialize instruction header. */
-	RespInstr.IsVirtualFile = 0;
-	RespInstr.IsChunkActive = 0;
-	RespInstr.IsRangeActive = 0;
-	RespInstr.IsTrailers = 0;
-	memset(RespInstr.AcceptLanguageHeader, 0,
-	       sizeof(RespInstr.AcceptLanguageHeader));
 	/* init */
+	memset(&RespInstr, 0, sizeof(RespInstr));
 	membuffer_init(&headers);
 	membuffer_init(&filename);
 

--- a/upnp/src/inc/webserver.h
+++ b/upnp/src/inc/webserver.h
@@ -56,8 +56,8 @@ struct SendInstruction
 	long RecvWriteSize;
 	/*! Cookie associated with the virtualDir. */
 	const void *Cookie;
-    /*! Cookie associated with the request. */
-    const void *RequestCookie;
+	/*! Cookie associated with the request. */
+	const void *RequestCookie;
 	/* Later few more member could be added depending
 	 * on the requirement.*/
 };


### PR DESCRIPTION
As the subject says. The callback cookie parameters in struct SendInstruction were not always zeroed on initialization. As usual, it was probably not a problem, until it would become one.