### PR TITLE
config.h: Remove DEBUG_TARGET

### DIFF
--- a/upnp/src/inc/config.h
+++ b/upnp/src/inc/config.h
@@ -401,20 +401,6 @@
 #endif
 /* @} */
 
-    
-/*!
- * \name DEBUG_TARGET
- *
- * The user has the option to redirect the library output debug messages 
- * to either the screen or to a log file.  All the output messages with 
- * debug level 0 will go to {\tt upnp.err} and messages with debug level 
- * greater than zero will be redirected to {\tt upnp.out}.
- *
- * @{
- */
-#define DEBUG_TARGET		1   
-/* @} */
-
 
 /*!
  * \name Other debugging features


### PR DESCRIPTION
The DEBUG_TARGET is no longer used, it was previously used in
upnpdebug.c to disable logging to a file, which now is done
by just not calling UpnpSetLogFileNames.