### PR TITLE
Remove and replace the list.h file

### DIFF
--- a/upnp/Makefile.am
+++ b/upnp/Makefile.am
@@ -26,7 +26,6 @@ upnpinclude_HEADERS = \
 	inc/ExtraHeaders.h \
 	inc/FileInfo.h \
 	inc/list.h \
-	inc/poison.h \
 	inc/StateVarComplete.h \
 	inc/StateVarRequest.h \
 	inc/SubscriptionRequest.h \
@@ -135,6 +134,7 @@ libupnp_la_SOURCES += \
 	src/genlib/util/strintmap.c \
 	src/genlib/util/upnp_timeout.c \
 	src/genlib/util/util.c \
+	src/genlib/util/list.c \
 	src/genlib/net/sock.c \
 	src/genlib/net/http/httpparser.c \
 	src/genlib/net/http/httpreadwrite.c \

--- a/upnp/inc/TemplateInclude.h
+++ b/upnp/inc/TemplateInclude.h
@@ -73,10 +73,8 @@
 	TEMPLATE_PROTOTYPE_LIST_AUX(CLASS, MEMBER)
 #define TEMPLATE_PROTOTYPE_LIST_AUX(CLASS, MEMBER) \
 	/*! DOC_##CLASS_##MEMBER */ \
-	EXPORT_SPEC const struct upnp_list_head *CLASS##_get_##MEMBER(const CLASS *p); \
-	EXPORT_SPEC void CLASS##_add_to_list_##MEMBER(CLASS *p, struct upnp_list_head *head); \
-	EXPORT_SPEC void CLASS##_remove_from_list_##MEMBER(CLASS *p); \
-	EXPORT_SPEC void CLASS##_replace_in_list_##MEMBER(CLASS *p, struct upnp_list_head *rep); \
+	EXPORT_SPEC const UpnpListHead *CLASS##_get_##MEMBER(const CLASS *p); \
+	EXPORT_SPEC void CLASS##_add_to_list_##MEMBER(CLASS *p, UpnpListHead *head); \
 
 
 /******************************************************************************/
@@ -126,7 +124,7 @@
 
 
 #include "ixml.h"       /* for DOMString, IXML_Document */
-#include "list.h"	/* for struct upnp_list_head */
+#include "list.h"	
 #include "UpnpGlobal.h" /* for EXPORT_SPEC */
 #include "UpnpString.h"
 

--- a/upnp/inc/TemplateSource.h
+++ b/upnp/inc/TemplateSource.h
@@ -29,7 +29,7 @@
 /******************************************************************************/
 #define TEMPLATE_DEFINITION_INT(MEMBER, TYPE)		TYPE m_##MEMBER;
 #define TEMPLATE_DEFINITION_BUFFER(MEMBER, TYPE)	TYPE m_##MEMBER;
-#define TEMPLATE_DEFINITION_LIST(MEMBER)		struct upnp_list_head m_##MEMBER;
+#define TEMPLATE_DEFINITION_LIST(MEMBER)		    UpnpListHead m_##MEMBER;
 #define TEMPLATE_DEFINITION_OBJECT(MEMBER, TYPE)	TYPE *m_##MEMBER;
 #define TEMPLATE_DEFINITION_STRING(MEMBER)		UpnpString *m_##MEMBER;
 #define TEMPLATE_DEFINITION_DOMSTRING(MEMBER)		DOMString m_##MEMBER;
@@ -38,7 +38,7 @@
 #define TEMPLATE_CONSTRUCTOR_INT(MEMBER, TYPE)		/* p->m_##MEMBER = 0; */
 #define TEMPLATE_CONSTRUCTOR_BUFFER(MEMBER, TYPE)	\
 	/* memset(&p->m_##MEMBER, 0, sizeof (TYPE)); */
-#define TEMPLATE_CONSTRUCTOR_LIST(MEMBER, TYPE)		UPNP_INIT_LIST_HEAD(&p->m_##MEMBER);
+#define TEMPLATE_CONSTRUCTOR_LIST(MEMBER, TYPE)		UpnpListInit(&p->m_##MEMBER);
 #define TEMPLATE_CONSTRUCTOR_OBJECT(MEMBER, TYPE)	p->m_##MEMBER = TYPE##_new();
 #define TEMPLATE_CONSTRUCTOR_STRING(MEMBER)		p->m_##MEMBER = UpnpString_new();
 #define TEMPLATE_CONSTRUCTOR_DOMSTRING(MEMBER)		 p->m_##MEMBER = NULL;
@@ -46,7 +46,7 @@
 /******************************************************************************/
 #define TEMPLATE_DESTRUCTOR_INT(MEMBER, TYPE)		p->m_##MEMBER = 0;
 #define TEMPLATE_DESTRUCTOR_BUFFER(MEMBER, TYPE)	memset(&p->m_##MEMBER, 0, sizeof (TYPE));
-#define TEMPLATE_DESTRUCTOR_LIST(MEMBER)		upnp_list_del(&p->m_##MEMBER);
+#define TEMPLATE_DESTRUCTOR_LIST(MEMBER)		UpnpListInit(&p->m_##MEMBER);
 #define TEMPLATE_DESTRUCTOR_OBJECT(MEMBER, TYPE)	TYPE##_delete(p->m_##MEMBER); p->m_##MEMBER = NULL;
 #define TEMPLATE_DESTRUCTOR_STRING(MEMBER)		UpnpString_delete(p->m_##MEMBER); p->m_##MEMBER = NULL;
 #define TEMPLATE_DESTRUCTOR_DOMSTRING(MEMBER)		ixmlFreeDOMString(p->m_##MEMBER); p->m_##MEMBER = NULL;
@@ -96,24 +96,15 @@ void CLASS##_clear_##MEMBER(CLASS *p) \
 #define TEMPLATE_METHODS_LIST(CLASS, MEMBER) \
 	TEMPLATE_METHODS_LIST_AUX(CLASS, MEMBER)
 #define TEMPLATE_METHODS_LIST_AUX(CLASS, MEMBER) \
-const struct upnp_list_head *CLASS##_get_##MEMBER(const CLASS *p) \
+const UpnpListHead *CLASS##_get_##MEMBER(const CLASS *p) \
 { \
-	return (struct upnp_list_head *)&((struct S##CLASS *)p)->m_##MEMBER; \
+	return (UpnpListHead *)&((struct S##CLASS *)p)->m_##MEMBER;	\
 } \
 \
-void CLASS##_add_to_list_##MEMBER(CLASS *p, struct upnp_list_head *head) \
+void CLASS##_add_to_list_##MEMBER(CLASS *p, struct UpnpListHead *head) \
 { \
-	upnp_list_add(&((struct S##CLASS *)p)->m_##MEMBER, head); \
-} \
-\
-void CLASS##_remove_from_list_##MEMBER(CLASS *p) \
-{ \
-	upnp_list_del_init(&((struct S##CLASS *)p)->m_##MEMBER); \
-} \
-\
-void CLASS##_replace_in_list_##MEMBER(CLASS *p, struct upnp_list_head *rep) \
-{ \
-	upnp_list_replace_init(&((struct S##CLASS *)p)->m_##MEMBER, rep); \
+	UpnpListHead *list = &((struct S##CLASS *)p)->m_##MEMBER; \
+	UpnpListInsert(list, UpnpListEnd(list), head);			\
 } \
 
 

--- a/upnp/src/genlib/net/http/httpreadwrite.c
+++ b/upnp/src/genlib/net/http/httpreadwrite.c
@@ -1505,13 +1505,14 @@ int http_MakeMessage(membuffer *buf, int http_major_version,
 	while ((c = *fmt++)) {
 		if (c == 'E') {
 			/* list of extra headers */
-			struct upnp_list_head *pos;
-			struct upnp_list_head *head;
+			UpnpListIter pos;
+			UpnpListHead *head;
 			UpnpExtraHeaders *extra;
 			const DOMString resp;
-			head = (struct upnp_list_head *)va_arg(argp, struct upnp_list_head *);
+			head = (UpnpListHead *)va_arg(argp, UpnpListHead *);
 			if (head) {
-				upnp_list_for_each(pos, head) {
+				for (pos = UpnpListBegin(head); pos != UpnpListEnd(head);
+					 pos = UpnpListNext(head, pos)) {
 					extra = (UpnpExtraHeaders *)pos;
 					resp = UpnpExtraHeaders_get_resp(extra);
 					if (resp) {

--- a/upnp/src/genlib/util/list.c
+++ b/upnp/src/genlib/util/list.c
@@ -1,6 +1,3 @@
-#ifndef _UPNP_LIST_H_
-#define _UPNP_LIST_H_
-
 /*******************************************************************************
  *
  * Copyright (c) 2000-2003 Intel Corporation 
@@ -33,41 +30,42 @@
  *
  ******************************************************************************/
 
-/** Trivial list management interface, patterned on std::list. It aims more at
- * being familiar than at being minimal. The implementation does not perform
- * any allocation or deallocation. 
- */
+#include "list.h"
 
+void UpnpListInit(UpnpListHead *list)
+{
+	list->next = list;
+	list->prev = list;
+}
 
-/** list anchor structure. This should be the *first* entry in list
- *  member objects, except if you want to do member offset arithmetic
- *  instead of simple casts (look up "containerof"). The list code itself 
- *  does not care. */
-typedef struct UpnpListHead {
-	struct UpnpListHead *next, *prev;
-} UpnpListHead;
+UpnpListIter UpnpListBegin(UpnpListHead *list)
+{
+	return list->next;
+}
 
-/** List iterator. Not strictly necessary, but clarifies the interface. */
-typedef UpnpListHead *UpnpListIter;
+UpnpListIter UpnpListEnd(UpnpListHead *list)
+{
+	return list;
+}
 
-/** Initialize empty list */
-extern void UpnpListInit(UpnpListHead *list);
+UpnpListIter UpnpListNext(UpnpListHead *list, UpnpListIter pos)
+{
+	return pos->next;
+}
 
-/** Return iterator pointing to the first list element, or
- *  UpnpListEnd(list) if the list is empty */
-extern UpnpListIter UpnpListBegin(UpnpListHead *list);
+UpnpListIter UpnpListInsert(UpnpListHead *list, UpnpListIter pos,
+							UpnpListHead *elt)
+{
+	elt->prev = pos->prev;
+	elt->next = pos;
+	pos->prev->next = elt;
+	pos->prev = elt;
+	return elt;
+}
 
-/** Return end of list sentinel iterator (not an element) */
-extern UpnpListIter UpnpListEnd(UpnpListHead *list);
-
-/** Return iterator pointing to element after pos, or end() */
-extern UpnpListIter UpnpListNext(UpnpListHead *list, UpnpListIter pos);
-
-/** Insert element before pos, returns iterator pointing to inserted element. */
-extern UpnpListIter UpnpListInsert(UpnpListHead *list, UpnpListIter pos,
-                                       UpnpListHead *elt);
-
-/** Erase element at pos, return next one, or end()*/
-extern UpnpListIter UpnpListErase(UpnpListHead *list, UpnpListIter pos);
-
-#endif /* _UPNPLISTH_ */
+UpnpListIter UpnpListErase(UpnpListHead *list, UpnpListIter pos)
+{
+	pos->prev->next = pos->next;
+	pos->next->prev = pos->prev;
+	return pos->next;
+}


### PR DESCRIPTION
This is an example of replacing the current list.h 
The list interface is modeled on std::list (a small subset, adapted for c).
I have not tested the implementation with actual extraheaders, I am having trouble building Gerbera
No more macros, but we have to export the list interface routines.
I think that this is much easier to understand than the previous, but this is also a question of taste...