### PR TITLE
UpnpEnableWebserver: Error correctly when web server compiled-out

### DIFF
--- a/upnp/inc/upnp.h
+++ b/upnp/inc/upnp.h
@@ -2774,6 +2774,8 @@ EXPORT_SPEC int UpnpVirtualDir_set_CloseCallback(VDCallback_Close callback);
  *       \li \c UPNP_E_SUCCESS: The operation completed successfully.
  *       \li \c UPNP_E_OUTOF_MEMORY: The web server could not be started due to
  *		an out-of-memory condition.
+ *		 \li \c UPNP_E_NO_WEB_SERVER: The internal web server has been compiled
+ *		out so it can't be enabled or disabled.
  */
 EXPORT_SPEC int UpnpEnableWebserver(
 	/*! [in] \c 1 to enable, \c 0 to disable. */

--- a/upnp/src/api/upnpapi.c
+++ b/upnp/src/api/upnpapi.c
@@ -4722,9 +4722,11 @@ int UpnpEnableWebserver(int enable)
 		bWebServerState = WEB_SERVER_DISABLED;
 		SetHTTPGetCallback(NULL);
 	}
-#endif /* INTERNAL_WEB_SERVER */
 
 	return UPNP_E_SUCCESS;
+#else /* Internal web server disabled */
+	return UPNP_E_NO_WEB_SERVER;
+#endif /* INTERNAL_WEB_SERVER */
 }
 
 /*!


### PR DESCRIPTION
Return UPNP_E_NO_WEB_SERVER when webs erver was compiled-out, as then
it is impossible to enable/disable it.